### PR TITLE
Fix: PADV-646 - Default values for first access and last access.

### DIFF
--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -32,17 +32,29 @@ const getColumns = props => [
   {
     Header: 'Created',
     accessor: 'created',
-    Cell: ({ row }) => new Date(row.values.created).toUTCString(),
+    Cell: ({ row }) => (
+      row.values.created
+        ? new Date(row.values.created).toUTCString()
+        : ''
+    ),
   },
   {
     Header: 'First Access',
     accessor: 'first_access',
-    Cell: ({ row }) => new Date(row.values.first_access).toUTCString(),
+    Cell: ({ row }) => (
+      row.values.first_access
+        ? new Date(row.values.first_access).toUTCString()
+        : ''
+    ),
   },
   {
     Header: 'Last Access',
     accessor: 'last_access',
-    Cell: ({ row }) => new Date(row.values.last_access).toUTCString(),
+    Cell: ({ row }) => (
+      row.values.last_access
+        ? new Date(row.values.last_access).toUTCString()
+        : ''
+    ),
   },
   {
     Header: 'Grade',


### PR DESCRIPTION
## Description

This PR is a fix of the implementation made in https://agile-jira.pearson.com/browse/PADV-646.

## Changes made

- [x] Add validation in first_access, last_access and created columns.

## Screenshots

The error is when the endpoint returns a null value for first access and last_access. The method `Date(row.values.first_access).toUTCString()` returns a default Date. For example, as you can see, there are rows with values ​​from the year `1970`.

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/95d832cf-03da-4bf2-8a56-50d7d206f311)

The desired behavior is that if those values ​​are not there, it does not return anything as shown in the following screenshot:

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/e2107c52-0d2d-4d31-998e-ab6815466f13)

## How to test

- Clone the Institution Portal MFE
- Run npm install.
- Run npm run start