### PR TITLE
Fix: numPages in pagination adding camelCaseObject.

### DIFF
--- a/src/features/Students/StudentsPage/index.jsx
+++ b/src/features/Students/StudentsPage/index.jsx
@@ -9,6 +9,7 @@ import { MenuIcon } from '@edx/frontend-component-header/dist/Icons';
 
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import React, { useEffect, useState, useReducer } from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
 import {
   ActionRow,
   Button,
@@ -44,8 +45,7 @@ const reducer = (state, action) => {
     case 'FETCH_REQUEST':
       return { ...state, status: RequestStatus.LOADING };
     case 'FETCH_SUCCESS': {
-      const { results, count } = action.payload;
-      const numPages = count;
+      const { results, count, numPages } = action.payload;
       return {
         ...state,
         status: RequestStatus.SUCCESS,
@@ -96,7 +96,7 @@ const StudentsPage = () => {
     dispatch({ type: 'FETCH_REQUEST' });
 
     try {
-      const response = await getStudentbyInstitutionAdmin(currentPage, filters);
+      const response = camelCaseObject(await getStudentbyInstitutionAdmin(currentPage, filters));
       dispatch({ type: 'FETCH_SUCCESS', payload: response.data });
     } catch (error) {
       dispatch({ type: 'FETCH_FAILURE', payload: error });

--- a/src/features/Students/StudentsTable/_test_/columns.test.jsx
+++ b/src/features/Students/StudentsTable/_test_/columns.test.jsx
@@ -21,16 +21,16 @@ describe('getColumns', () => {
     ] = columns;
 
     expect(nameColumn).toHaveProperty('Header', 'Name');
-    expect(nameColumn).toHaveProperty('accessor', 'learner_name');
+    expect(nameColumn).toHaveProperty('accessor', 'learnerName');
 
     expect(emailColumn).toHaveProperty('Header', 'Email');
-    expect(emailColumn).toHaveProperty('accessor', 'learner_email');
+    expect(emailColumn).toHaveProperty('accessor', 'learnerEmail');
 
     expect(courseNameColumn).toHaveProperty('Header', 'Class Name');
-    expect(courseNameColumn).toHaveProperty('accessor', 'ccx_name');
+    expect(courseNameColumn).toHaveProperty('accessor', 'ccxName');
 
     expect(ClassIdColumn).toHaveProperty('Header', 'Class Id');
-    expect(ClassIdColumn).toHaveProperty('accessor', 'ccx_id');
+    expect(ClassIdColumn).toHaveProperty('accessor', 'ccxId');
 
     expect(instructorsColumn).toHaveProperty('Header', 'Instructors');
     expect(instructorsColumn).toHaveProperty('accessor', 'instructors');
@@ -39,10 +39,10 @@ describe('getColumns', () => {
     expect(createdColumn).toHaveProperty('accessor', 'created');
 
     expect(firstAccessColumn).toHaveProperty('Header', 'First Access');
-    expect(firstAccessColumn).toHaveProperty('accessor', 'first_access');
+    expect(firstAccessColumn).toHaveProperty('accessor', 'firstAccess');
 
     expect(lastAccessColumn).toHaveProperty('Header', 'Last Access');
-    expect(lastAccessColumn).toHaveProperty('accessor', 'last_access');
+    expect(lastAccessColumn).toHaveProperty('accessor', 'lastAccess');
 
     expect(gradeColumn).toHaveProperty('Header', 'Grade');
     expect(gradeColumn).toHaveProperty('accessor', 'grade');

--- a/src/features/Students/StudentsTable/_test_/index.test.jsx
+++ b/src/features/Students/StudentsTable/_test_/index.test.jsx
@@ -14,23 +14,23 @@ describe('Student Table', () => {
   test('renders StudentsTable with data', () => {
     const data = [
       {
-        learner_name: 'Student 1',
-        learner_email: 'student1@example.com',
-        ccx_name: 'CCX 1',
+        learnerName: 'Student 1',
+        learnerEmail: 'student1@example.com',
+        ccxName: 'CCX 1',
         instructors: ['Instructor 1'],
         created: 'Fri, 25 Aug 2023 19:01:22 GMT',
-        first_access: 'Fri, 25 Aug 2023 19:01:23 GMT',
-        last_access: 'Fri, 25 Aug 2023 20:20:22 GMT',
+        firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
+        lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
         grade: true,
       },
       {
-        learner_name: 'Student 2',
-        learner_email: 'student2@example.com',
-        ccx_name: 'CCX 2',
+        learnerName: 'Student 2',
+        learnerEmail: 'student2@example.com',
+        ccxName: 'CCX 2',
         instructors: ['Instructor 2'],
         created: 'Sat, 26 Aug 2023 19:01:22 GMT',
-        first_access: 'Sat, 26 Aug 2023 19:01:24 GMT',
-        last_access: 'Sat, 26 Aug 2023 21:22:22 GMT',
+        firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
+        lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
         grade: false,
       },
     ];

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -5,19 +5,19 @@ import { Badge, Button } from '@edx/paragon';
 const getColumns = props => [
   {
     Header: 'Name',
-    accessor: 'learner_name',
+    accessor: 'learnerName',
   },
   {
     Header: 'Email',
-    accessor: 'learner_email',
+    accessor: 'learnerEmail',
   },
   {
     Header: 'Class Name',
-    accessor: 'ccx_name',
+    accessor: 'ccxName',
   },
   {
     Header: 'Class Id',
-    accessor: 'ccx_id',
+    accessor: 'ccxId',
     disableSortBy: true,
   },
   {
@@ -40,19 +40,19 @@ const getColumns = props => [
   },
   {
     Header: 'First Access',
-    accessor: 'first_access',
+    accessor: 'firstAccess',
     Cell: ({ row }) => (
-      row.values.first_access
-        ? new Date(row.values.first_access).toUTCString()
+      row.values.firstAccess
+        ? new Date(row.values.firstAccess).toUTCString()
         : ''
     ),
   },
   {
     Header: 'Last Access',
-    accessor: 'last_access',
+    accessor: 'lastAccess',
     Cell: ({ row }) => (
-      row.values.last_access
-        ? new Date(row.values.last_access).toUTCString()
+      row.values.lastAccess
+        ? new Date(row.values.lastAccess).toUTCString()
         : ''
     ),
   },


### PR DESCRIPTION
## Description

In accordance with the Minimum Viable Product (MVP) requirements and following the discovery made in https://agile-jira.pearson.com/browse/PADV-645 we need to implement a way to obtain first access, last access and grade of a CCX.

## Changes Made

- [x] Add camelCaseObject fetching the API endpoint.
- [x] Change to camelcase the related strings.
- [x] Fix numPages in Students view.

Before:

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/826afc57-f90b-47fd-8265-28d668da0649)

After:

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/67f0934d-82a2-4a36-a9d1-d527b7b5ddef)

- [x] Update tests.

## How to test

- Up openedx services (including Course Operations)
- Run `npm install`
- Run `npm start`
- Go to `http://localhost:1980/`
- See the data by Institution Admin or Global Admin