### PR TITLE
Fix - Missed camelCase calls in StudentTable.

### DIFF
--- a/src/features/Students/StudentsPage/_test_/index.test.jsx
+++ b/src/features/Students/StudentsPage/_test_/index.test.jsx
@@ -19,16 +19,16 @@ const mockResponse = {
   data: {
     results: [
       {
-        learner_name: 'Student 1',
-        learner_email: 'student1@example.com',
-        ccx_name: 'CCX 1',
+        learnerName: 'Student 1',
+        learnerEmail: 'student1@example.com',
+        ccxName: 'CCX 1',
         instructors: ['Instructor 1'],
         created: 'Fri, 25 Aug 2023 19:01:22 GMT',
       },
       {
-        learner_name: 'Student 2',
-        learner_email: 'student2@example.com',
-        ccx_name: 'CCX 2',
+        learnerName: 'Student 2',
+        learnerEmail: 'student2@example.com',
+        ccxName: 'CCX 2',
         instructors: ['Instructor 2'],
         created: 'Sat, 26 Aug 2023 19:01:22 GMT',
       },

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -77,7 +77,7 @@ const getColumns = props => [
   },
 ];
 
-// We don't need to show ccx_id column but we need it to use handleStudentsActions.
-const hideColumns = { hiddenColumns: ['ccx_id'] };
+// We don't need to show ccxId column but we need it to use handleStudentsActions.
+const hideColumns = { hiddenColumns: ['ccxId'] };
 
 export { hideColumns, getColumns };

--- a/src/features/Students/StudentsTable/index.jsx
+++ b/src/features/Students/StudentsTable/index.jsx
@@ -22,11 +22,11 @@ const StudentsTable = ({
   const [selectedRow, setRow] = useState({});
   const COLUMNS = useMemo(() => getColumns({ openAlertModal, setRow }), [openAlertModal]);
   const enrollmentData = new FormData();
-  enrollmentData.append('identifiers', selectedRow.learner_email);
+  enrollmentData.append('identifiers', selectedRow.learnerEmail);
   enrollmentData.append('action', 'unenroll');
 
   const handleStudentsActions = async () => {
-    await handleEnrollments(enrollmentData, selectedRow.ccx_id);
+    await handleEnrollments(enrollmentData, selectedRow.ccxId);
     fetchData();
     closeAlertModal();
   };
@@ -62,7 +62,7 @@ const StudentsTable = ({
         )}
       >
         <p>
-          Learner with email <b>{selectedRow.learner_email}</b> will be revoked from <b>{selectedRow.ccx_name}</b>
+          Learner with email <b>{selectedRow.learnerEmail}</b> will be revoked from <b>{selectedRow.ccxName}</b>
         </p>
       </AlertModal>
     </IntlProvider>


### PR DESCRIPTION
## Description

In accordance with the Minimum Viable Product (MVP) we need to Revoke pending enrollments using the MFE. The fix implemented in https://github.com/Pearson-Advance/frontend-app-institution-portal/pull/9 change the way to access to the keys, now using CamelCase. For enrollmentData used for the `handleEnrollments` API call the respective change was not made.

## Changes Made

- [x] Change key to CamelCase in enrollmentData in StudentsTable.
- [x] Change key of ccxId to hide column in StudentsTable.

## How to test

- Up openedx services (including Course Operations)
- Run `npm install`
- Run `npm start`
- Go to `http://localhost:1980/`
- Go to StudentsPage and revoke pending enrollment.