### PR TITLE
PADV-912 - Show all courses for Global Admin and filtered courses for Institution Admin.

### DIFF
--- a/src/features/Courses/CoursesPage/index.jsx
+++ b/src/features/Courses/CoursesPage/index.jsx
@@ -33,9 +33,9 @@ const CoursesPage = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [currentPage, setCurrentPage] = useState(1);
   const [filters, setFilters] = useState({});
-
-  let id = 0;
-  if (stateInstitution.length > 0) {
+  // check this after implementation of selector institution
+  let id = '';
+  if (stateInstitution.length === 1) {
     id = stateInstitution[0].id;
   }
 
@@ -52,9 +52,7 @@ const CoursesPage = () => {
   };
 
   useEffect(() => {
-    if (id > 0) {
-      fetchData(filters);
-    }
+    fetchData(filters);
   }, [currentPage, id, filters]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handlePagination = (targetPage) => {

--- a/src/features/Instructors/InstructorsFilters/_test_/index.test.jsx
+++ b/src/features/Instructors/InstructorsFilters/_test_/index.test.jsx
@@ -3,6 +3,10 @@ import { render, fireEvent, act } from '@testing-library/react';
 import InstructorsFilters from 'features/Instructors/InstructorsFilters';
 import '@testing-library/jest-dom/extend-expect';
 
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
 describe('InstructorsFilters Component', () => {
   const mockSetFilters = jest.fn();
 

--- a/src/features/Instructors/InstructorsFilters/index.jsx
+++ b/src/features/Instructors/InstructorsFilters/index.jsx
@@ -34,8 +34,8 @@ const InstructorsFilters = ({ fetchData, resetPagination, setFilters }) => {
   const [instructorEmail, setInstructorEmail] = useState('');
   const [courseSelected, setCourseSelected] = useState(null);
   // check this after implementation of selector institution
-  let id = 0;
-  if (stateInstitution.length > 0) {
+  let id = '';
+  if (stateInstitution.length === 1) {
     id = stateInstitution[0].id;
   }
 
@@ -74,9 +74,7 @@ const InstructorsFilters = ({ fetchData, resetPagination, setFilters }) => {
   };
 
   useEffect(() => {
-    if (id > 0) {
-      fetchCoursesData();
-    } // eslint-disable-next-line react-hooks/exhaustive-deps
+    fetchCoursesData(); // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   useEffect(() => {

--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -45,8 +45,8 @@ const StudentsFilters = ({ resetPagination, fetchData, setFilters }) => {
   const [statusSelected, setStatusSelected] = useState(null);
   const [examSelected, setExamSelected] = useState(null);
   // check this after implementation of selector institution
-  let id = 0;
-  if (stateInstitution.length > 0) {
+  let id = '';
+  if (stateInstitution.length === 1) {
     id = stateInstitution[0].id;
   }
 
@@ -87,9 +87,7 @@ const StudentsFilters = ({ resetPagination, fetchData, setFilters }) => {
   };
 
   useEffect(() => {
-    if (id > 0) {
-      fetchCoursesData();
-    } // eslint-disable-next-line react-hooks/exhaustive-deps
+    fetchCoursesData(); // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   useEffect(() => {

--- a/src/features/Students/data/api.js
+++ b/src/features/Students/data/api.js
@@ -24,9 +24,11 @@ function handleEnrollments(data, courseId) {
 }
 
 function getClassesByInstitution(institutionId, courseName) {
+  const encodedCourseName = encodeURIComponent(courseName);
+
   return getAuthenticatedHttpClient().get(
     `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/classes`
-    + `/?limit=false&institution_id=${institutionId}&course_name=${courseName}`,
+    + `/?limit=false&institution_id=${institutionId}&course_name=${encodedCourseName}`,
   );
 }
 


### PR DESCRIPTION
## Description

This PR implement a Fix to show all Courses when the user is Global Admin evaluating the lenght of the Institutions obtained. This is because for an Institution Admin you should obtain just one institution to filter everything. I also added some changes to pass the encoded parameter to the backend because we had a problem filtering out special characters.

## Changes Made

- [x] Add encoded parameter in `getClassesByInstitution`
- [x] Change the id default value in the views which call `getCoursesByInstitution`.

## How to test

- Up an environment and run the MFE
- Create data for different Institutions, Courses and also CCX's (Filter by Course and CCX in Students view).
- Sing In as Global Admin and review that all Courses for all Institutions are in the Courses view and in different filters.
- Sign In as Institution Admin and see that the data is filtered for the Institution associated.