### PR TITLE
feat: Add file upload functionality for VSCode integration and tweak …

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+  },
+  "include": ["src"],
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
-    "test": "fedx-scripts jest --coverage --passWithNoTests"
+    "test": "fedx-scripts jest --coverage --passWithNoTests",
+    "test:watch": "fedx-scripts jest --coverage --passWithNoTests --watch"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR introduces a new `jsconfig.json` file. It sets the base URL for module resolution to the `src` directory, enhancing project organization and simplifying imports across JavaScript files by establishing a consistent base path ( for VsCode ).

Additionally, the `package.json` file has been updated. The modification to the `test` script now includes the `--watch` flag. This improvement enables Jest to run tests in watch mode, providing developers with immediate feedback during test development and refinement.
