### PR TITLE
PADV-1068 fix: assign instructors list

### DIFF
--- a/src/features/Instructors/AssignInstructors/index.jsx
+++ b/src/features/Instructors/AssignInstructors/index.jsx
@@ -9,7 +9,10 @@ import AssignTable from 'features/Instructors/AssignInstructors/AssignTable';
 
 import { fetchInstructorsData, assignInstructors } from 'features/Instructors/data';
 import {
-  updateCurrentPage, updateFilters, updateClassSelected,
+  updateCurrentPage,
+  updateFilters,
+  updateClassSelected,
+  resetRowSelect,
 } from 'features/Instructors/data/slice';
 
 import { initialPage } from 'features/constants';
@@ -22,6 +25,7 @@ const AssignInstructors = ({ isOpen, close }) => {
   const rowsSelected = useSelector((state) => state.instructors.rowsSelected);
   const classId = useSelector((state) => state.instructors.classSelected);
   const [currentPage, setCurrentPage] = useState(initialPage);
+  const isButtonDisabled = rowsSelected.length === 0;
 
   const resetPagination = () => {
     setCurrentPage(initialPage);
@@ -54,6 +58,7 @@ const AssignInstructors = ({ isOpen, close }) => {
     if (!isOpen) {
       dispatch(updateFilters({}));
       dispatch(updateClassSelected(''));
+      dispatch(resetRowSelect());
     }
   }, [isOpen, dispatch]);
 
@@ -86,7 +91,13 @@ const AssignInstructors = ({ isOpen, close }) => {
         )}
         <div className="d-flex justify-content-end">
           <ModalCloseButton className="btntpz btn-text btn-tertiary">Cancel</ModalCloseButton>
-          <Button onClick={handleAssignInstructors} data-testid="assignButton">Assign instructor</Button>
+          <Button
+            onClick={handleAssignInstructors}
+            data-testid="assignButton"
+            disabled={isButtonDisabled}
+          >
+            Assign instructor
+          </Button>
         </div>
       </ModalDialog.Body>
     </ModalDialog>

--- a/src/features/Instructors/data/_test_/redux.test.js
+++ b/src/features/Instructors/data/_test_/redux.test.js
@@ -5,7 +5,12 @@ import {
   fetchInstructorsData, fetchCoursesData, addInstructor,
 } from 'features/Instructors/data/thunks';
 import {
-  updateCurrentPage, updateFilters, updateClassSelected, addRowSelect, deleteRowSelect,
+  updateCurrentPage,
+  updateFilters,
+  updateClassSelected,
+  addRowSelect,
+  deleteRowSelect,
+  resetRowSelect,
 } from 'features/Instructors/data/slice';
 import { executeThunk } from 'test-utils';
 import { initializeStore } from 'store';
@@ -221,5 +226,12 @@ describe('Instructors redux tests', () => {
 
     expect(store.getState().instructors.addInstructor.status)
       .toEqual('error');
+  });
+
+  test('Reset rowsSelected', () => {
+    const expectState = [];
+
+    store.dispatch(resetRowSelect());
+    expect(store.getState().instructors.rowsSelected).toEqual(expectState);
   });
 });

--- a/src/features/Instructors/data/slice.js
+++ b/src/features/Instructors/data/slice.js
@@ -82,6 +82,9 @@ export const instructorsSlice = createSlice({
     deleteRowSelect: (state, { payload }) => {
       state.rowsSelected = state.rowsSelected.filter(row => row !== payload);
     },
+    resetRowSelect: (state) => {
+      state.rowsSelected = [];
+    },
     addInstructorRequest: (state) => {
       state.addInstructor.status = RequestStatus.LOADING;
     },
@@ -110,6 +113,7 @@ export const {
   assingInstructorsFailed,
   addRowSelect,
   deleteRowSelect,
+  resetRowSelect,
   addInstructorRequest,
   addInstructorSuccess,
   addInstructorFailed,

--- a/src/features/Instructors/data/thunks.js
+++ b/src/features/Instructors/data/thunks.js
@@ -15,6 +15,7 @@ import {
   addInstructorRequest,
   addInstructorSuccess,
   addInstructorFailed,
+  resetRowSelect,
 } from 'features/Instructors/data/slice';
 import { fetchClassesData as fetchClassesDataHome } from 'features/Dashboard/data';
 import { initialPage } from 'features/constants';
@@ -63,6 +64,7 @@ function assignInstructors(data, classId, institutionId) {
       logError(error);
     } finally {
       dispatch(fetchClassesDataHome(institutionId, false));
+      dispatch(resetRowSelect());
     }
   };
 }


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1068

### Description
Fix instructors list select in assign modal

### Changes made
Reset instructors list selected after close modal and after call assign service
Disabled assign button if there are not instructors selected
Update tests

### Screenshots
![assignInstructors](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/36944773/db6ae39b-e867-49b6-97c4-ed33737650ce)


### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/dashboard