### PR TITLE
PADV-1045 - Add min students column in classes table view

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -3,13 +3,14 @@ import { columns } from 'features/Classes/ClassesTable/columns';
 describe('columns', () => {
   test('returns an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(7);
+    expect(columns).toHaveLength(8);
 
     const [
       masterCourseNameColumn,
       classNameColumn,
       startDateColumn,
       endDateColumn,
+      minStudentsAllowedColumn,
       numberOfStudentsColumn,
       maxStudentsColumn,
       instructorsColumn,
@@ -26,6 +27,9 @@ describe('columns', () => {
 
     expect(endDateColumn).toHaveProperty('Header', 'End Date');
     expect(endDateColumn).toHaveProperty('accessor', 'endDate');
+
+    expect(minStudentsAllowedColumn).toHaveProperty('Header', 'Min');
+    expect(minStudentsAllowedColumn).toHaveProperty('accessor', 'minStudentsAllowed');
 
     expect(numberOfStudentsColumn).toHaveProperty('Header', 'Students Enrolled');
     expect(numberOfStudentsColumn).toHaveProperty('accessor', 'numberOfStudents');

--- a/src/features/Classes/ClassesTable/_test_/index.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/index.test.jsx
@@ -17,6 +17,7 @@ const mockStore = {
           className: 'Demo Class 1',
           startDate: '09/21/24',
           endDate: null,
+          min: 50,
           numberOfStudents: 1,
           maxStudents: 100,
           instructors: ['instructor_1'],
@@ -26,6 +27,7 @@ const mockStore = {
           className: 'Demo Class 2',
           startDate: '09/21/25',
           endDate: null,
+          min: 200,
           numberOfStudents: 1,
           maxStudents: 10,
           instructors: ['instructor_2', 'instructor_3'],
@@ -52,6 +54,8 @@ describe('ClassesPage', () => {
       expect(component.container).toHaveTextContent('Demo Class 2');
       expect(component.container).toHaveTextContent('09/21/24');
       expect(component.container).toHaveTextContent('09/21/25');
+      expect(component.container).toHaveTextContent('50');
+      expect(component.container).toHaveTextContent('200');
       expect(component.container).toHaveTextContent('100');
       expect(component.container).toHaveTextContent('10');
       expect(component.container).toHaveTextContent('instructor_1');

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -22,6 +22,10 @@ const columns = [
     Cell: ({ row }) => (row.values.endDate ? format(row.values.endDate, 'MM/dd/yy') : ''),
   },
   {
+    Header: 'Min',
+    accessor: 'minStudentsAllowed',
+  },
+  {
     Header: 'Students Enrolled',
     accessor: 'numberOfStudents',
   },

--- a/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
+++ b/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
@@ -11,12 +11,13 @@ import { columns } from 'features/Courses/CourseDetailTable/columns';
 describe('columns', () => {
   test('returns an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(7);
+    expect(columns).toHaveLength(8);
 
     const [
       className,
       instructor,
       enrollmentStatus,
+      minStudentsAllowed,
       studentsEnrolled,
       maxStudents,
       startDate,
@@ -28,6 +29,9 @@ describe('columns', () => {
 
     expect(instructor).toHaveProperty('Header', 'Instructor');
     expect(instructor).toHaveProperty('accessor', 'instructors');
+
+    expect(minStudentsAllowed).toHaveProperty('Header', 'Min');
+    expect(minStudentsAllowed).toHaveProperty('accessor', 'minStudentsAllowed');
 
     expect(enrollmentStatus).toHaveProperty('Header', 'Enrollment status');
     expect(enrollmentStatus).toHaveProperty('accessor', 'numberOfPendingStudents');
@@ -52,16 +56,16 @@ describe('columns', () => {
   });
 
   test('Should render the dates', () => {
-    const startDate = columns[5].Cell({ row: { values: { startDate: '2024-02-13T17:42:22Z' } } });
+    const startDate = columns[6].Cell({ row: { values: { startDate: '2024-02-13T17:42:22Z' } } });
     expect(startDate).toBe('02/13/24');
 
-    const endDate = columns[5].Cell({ row: { values: { startDate: '2024-04-13T17:42:22Z' } } });
+    const endDate = columns[6].Cell({ row: { values: { startDate: '2024-04-13T17:42:22Z' } } });
     expect(endDate).toBe('04/13/24');
 
-    const nullDate = columns[5].Cell({ row: { values: { startDate: null } } });
+    const nullDate = columns[6].Cell({ row: { values: { startDate: null } } });
     expect(nullDate).toBe('-');
 
-    const nullDate2 = columns[6].Cell({ row: { values: { startDate: null } } });
+    const nullDate2 = columns[7].Cell({ row: { values: { startDate: null } } });
     expect(nullDate2).toBe('-');
   });
 
@@ -80,7 +84,7 @@ describe('columns', () => {
   test('Should render the students enrolled', () => {
     const values = { row: { values: { numberOfStudents: 3, numberOfPendingStudents: 1 } } };
 
-    const studentsEnrolled = columns[3].Cell(values);
+    const studentsEnrolled = columns[4].Cell(values);
     expect(studentsEnrolled).toHaveProperty('type', 'span');
     expect(studentsEnrolled.props).toEqual({ children: 3 });
   });

--- a/src/features/Courses/CourseDetailTable/__test__/index.test.jsx
+++ b/src/features/Courses/CourseDetailTable/__test__/index.test.jsx
@@ -24,6 +24,7 @@ describe('Course Details Table', () => {
               className: 'Demo Class 1',
               startDate: '09/21/24',
               endDate: null,
+              min: 10,
               numberOfStudents: 1,
               maxStudents: 100,
               instructors: ['instructor_1'],
@@ -33,6 +34,7 @@ describe('Course Details Table', () => {
               className: 'Demo Class 2',
               startDate: '09/21/25',
               endDate: null,
+              min: 2,
               numberOfStudents: 2,
               maxStudents: 200,
               instructors: ['instructor_2'],
@@ -61,6 +63,7 @@ describe('Course Details Table', () => {
     expect(component.container).toHaveTextContent('Class');
     expect(component.container).toHaveTextContent('Instructor');
     expect(component.container).toHaveTextContent('Enrollment status');
+    expect(component.container).toHaveTextContent('Min');
     expect(component.container).toHaveTextContent('Students Enrolled');
     expect(component.container).toHaveTextContent('Max');
     expect(component.container).toHaveTextContent('Start date');

--- a/src/features/Courses/CourseDetailTable/columns.jsx
+++ b/src/features/Courses/CourseDetailTable/columns.jsx
@@ -75,6 +75,10 @@ const columns = [
     },
   },
   {
+    Header: 'Min',
+    accessor: 'minStudentsAllowed',
+  },
+  {
     Header: 'Students Enrolled',
     accessor: 'numberOfStudents',
     Cell: ({ row }) => (


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1045

### Description
Display min students in classes table in classes page and courses workflow.

### Changes made
- Add minimum students allowed column in ClassesTable.
- Add minimum students allowed column in CourseDetailTable.
- Update tests.

### Screenshots
- ClassesTable

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/d9d603bd-e3d0-41ea-a421-cf3a388308d3)

- CourseDetailTable

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/9644cb64-64e0-482f-8a5a-14192f6d1cba)




### How to test
Clone the Institution Portal MFE
Go to vue/PADV-1045 branch
Run npm install
Run npm run start
Go to http://localhost:1980/classes