### PR TITLE
PADV-988 - Courses view by license

### DIFF
--- a/src/features/Courses/data/slice.js
+++ b/src/features/Courses/data/slice.js
@@ -25,6 +25,9 @@ export const coursesSlice = createSlice({
   name: 'courses',
   initialState,
   reducers: {
+    resetCoursesTable: (state) => {
+      state.table = initialState.table;
+    },
     updateCurrentPage: (state, { payload }) => {
       state.table.currentPage = payload;
     },
@@ -64,6 +67,7 @@ export const coursesSlice = createSlice({
 });
 
 export const {
+  resetCoursesTable,
   updateCurrentPage,
   fetchCoursesDataRequest,
   fetchCoursesDataSuccess,

--- a/src/features/Dashboard/DashboardPage/_test_/index.test.jsx
+++ b/src/features/Dashboard/DashboardPage/_test_/index.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DashboardPage from 'features/Dashboard/DashboardPage';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -54,7 +55,11 @@ describe('DashboardPage component', () => {
   };
 
   const component = renderWithProviders(
-    <DashboardPage />,
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Route path="/dashboard">
+        <DashboardPage />
+      </Route>
+    </MemoryRouter>,
     { preloadedState: mockStore },
   );
 

--- a/src/features/Licenses/LicenseDetailTable/__test__/columns.test.jsx
+++ b/src/features/Licenses/LicenseDetailTable/__test__/columns.test.jsx
@@ -1,0 +1,16 @@
+import { columns } from 'features/Licenses/LicenseDetailTable/columns';
+
+describe('columns', () => {
+  test('returns an array of columns with correct properties', () => {
+    expect(columns).toBeInstanceOf(Array);
+    expect(columns).toHaveLength(2);
+
+    const [course, enrolled] = columns;
+
+    expect(course).toHaveProperty('Header', 'Course');
+    expect(course).toHaveProperty('accessor', 'masterCourseName');
+
+    expect(enrolled).toHaveProperty('Header', 'Enrolled');
+    expect(enrolled).toHaveProperty('accessor', 'numberOfStudents');
+  });
+});

--- a/src/features/Licenses/LicenseDetailTable/columns.jsx
+++ b/src/features/Licenses/LicenseDetailTable/columns.jsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/prop-types, no-nested-ternary */
+import { Link } from 'react-router-dom';
+
+const columns = [
+  {
+    Header: 'Course',
+    accessor: 'masterCourseName',
+    Cell: ({ row }) => (
+      <Link to={`/courses/${row.values.masterCourseName}`} className="link">{row.values.masterCourseName}</Link>
+    ),
+  },
+  {
+    Header: 'Enrolled',
+    accessor: 'numberOfStudents',
+  },
+];
+
+export { columns };

--- a/src/features/Licenses/LicensesDetailPage/__test__/index.test.jsx
+++ b/src/features/Licenses/LicensesDetailPage/__test__/index.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import '@testing-library/jest-dom/extend-expect';
+
+import { renderWithProviders } from 'test-utils';
+import LicensesDetailPage from 'features/Licenses/LicensesDetailPage';
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const mockStore = {
+  main: {
+    selectedInstitution: {
+      id: 1,
+      name: 'Institution 1',
+      shortName: 'Test',
+      active: true,
+      externalId: '',
+      created: '2023-06-22T22:48:56.124907Z',
+      modified: '2023-06-22T22:48:56.124907Z',
+      label: 'Institution 1',
+      value: 1,
+    },
+  },
+  courses: {
+    table: {
+      data: [
+        {
+          course: 'Demo Course 1',
+          enrolled: 3,
+        },
+        {
+          course: 'Demo Course 2',
+          enrolled: 10,
+        },
+      ],
+      count: 2,
+      num_pages: 1,
+      current_page: 1,
+    },
+  },
+  licenses: {
+    table: {
+      data: [
+        {
+          licenseName: 'License Demo',
+          purchasedSeats: 10,
+          numberOfStudents: 20,
+          numberOfPendingStudents: 10,
+        },
+      ],
+      count: 1,
+      num_pages: 1,
+      current_page: 1,
+    },
+  },
+};
+
+describe('LicensesDetailPage', () => {
+  test('Should render the table and the course info', async () => {
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/licenses/1']}>
+        <Route path="/licenses/:licenseId">
+          <LicensesDetailPage />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    waitFor(() => {
+      expect(component.container).toHaveTextContent('Demo Course 1');
+      expect(component.container).toHaveTextContent('Demo Course 2');
+      expect(component.container).toHaveTextContent('3');
+      expect(component.container).toHaveTextContent('10');
+    });
+  });
+});

--- a/src/features/Licenses/LicensesDetailPage/index.jsx
+++ b/src/features/Licenses/LicensesDetailPage/index.jsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Link, useParams, useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { Button } from 'react-paragon-topaz';
+import { Container, Pagination } from '@edx/paragon';
+import Table from 'features/Main/Table';
+import { columns } from 'features/Licenses/LicenseDetailTable/columns';
+import { fetchCoursesData } from 'features/Courses/data/thunks';
+import { resetCoursesTable, updateCurrentPage } from 'features/Courses/data/slice';
+import { fetchLicensesData } from 'features/Licenses/data';
+
+import { initialPage, licenseBuyLink } from 'features/constants';
+import 'features/Licenses/LicensesDetailPage/index.scss';
+
+const LicensesDetailPage = () => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const { licenseId } = useParams();
+
+  const institutionRef = useRef(undefined);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+
+  const defaultLicenseInfo = {
+    licenseName: '-',
+    purchasedSeats: '-',
+    numberOfStudents: '-',
+    numberOfPendingStudents: '-',
+  };
+
+  const institution = useSelector((state) => state.main.selectedInstitution);
+  const coursesTable = useSelector((state) => state.courses.table);
+  const licenseInfo = useSelector((state) => state.licenses.table.data)
+    .find((license) => license?.licenseId === parseInt(licenseId, 10)) || defaultLicenseInfo;
+
+  const handlePagination = (targetPage) => {
+    setCurrentPage(targetPage);
+    dispatch(updateCurrentPage(targetPage));
+  };
+
+  useEffect(() => {
+    if (institution.id) {
+      dispatch(fetchCoursesData(institution.id, initialPage, { license_id: licenseId }));
+      dispatch(fetchLicensesData(institution.id, initialPage, licenseId));
+    }
+
+    return () => {
+      dispatch(resetCoursesTable());
+    };
+  }, [dispatch, institution.id, licenseId]);
+
+  useEffect(() => {
+    if (institution.id !== undefined && institutionRef.current === undefined) {
+      institutionRef.current = institution.id;
+    }
+
+    if (institution.id !== institutionRef.current) {
+      history.push('/licenses');
+    }
+  }, [institution, history]);
+
+  return (
+    <Container size="xl" className="px-4">
+      <div className="d-flex justify-content-between mb-3 flex-column flex-sm-row">
+        <div className="d-flex align-items-start mb-3">
+          <Link to="/licenses" className="mr-3 mt-2 link">
+            <i className="fa-solid fa-arrow-left" />
+          </Link>
+          <div>
+            <h3 className="h2 mb-0 course-title">License pool: {licenseInfo.licenseName}</h3>
+            <p>
+              Courses for which a license can be used/assigned from this pool.
+            </p>
+          </div>
+        </div>
+        <div className="card-container d-flex justify-content-around align-items-center">
+          <div className="d-flex flex-column align-items-center">
+            <p className="title">Purchased</p>
+            <span className="value purchased-seats">
+              {licenseInfo.purchasedSeats}
+            </span>
+          </div>
+          <div className="separator mx-4" />
+          <div className="d-flex flex-column align-items-center">
+            <p className="title">Enrolled</p>
+            <span className="value">
+              {licenseInfo.numberOfStudents}
+            </span>
+          </div>
+          <div className="separator mx-4" />
+          <div className="d-flex flex-column align-items-center">
+            <p className="title">Remaining</p>
+            <span className="value number-of-pending">
+              {licenseInfo.numberOfPendingStudents}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="license-page-content-container">
+        <div className="flex-end">
+          <Button type="button">
+            <a className="btn-license" href={licenseBuyLink} target="_blank" rel="noreferrer">Buy a license</a>
+          </Button>
+        </div>
+        <Table columns={columns} data={coursesTable.data} count={coursesTable.count} text="No courses found." />
+        {coursesTable.numPages > 1 && (
+        <Pagination
+          paginationLabel="paginationNavigation"
+          pageCount={coursesTable.numPages}
+          currentPage={currentPage}
+          onPageSelect={handlePagination}
+          variant="reduced"
+          className="mx-auto pagination-table"
+          size="small"
+        />
+        )}
+      </div>
+    </Container>
+  );
+};
+
+export default LicensesDetailPage;

--- a/src/features/Licenses/LicensesDetailPage/index.scss
+++ b/src/features/Licenses/LicensesDetailPage/index.scss
@@ -1,0 +1,75 @@
+@import "assets/variables.scss";
+@import "assets/colors.scss";
+
+.course-title {
+  max-width: 700px;
+}
+
+.license-page-content-container {
+  border: 1px solid $gray-20;
+  border-radius: $border-radius-1;
+  padding: 24px 30px 30px 30px;
+  box-shadow: 0px 3px 12px 0px $gray-30;
+  background-color: $color-white;
+
+  .flex-end {
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: 20px;
+  }
+}
+
+.card-container {
+  height: 100px;
+  padding: 0 1.5rem;
+  padding-left: 2rem;
+  padding-right: 4rem;
+  background-color: $color-white;
+  border-radius: $border-radius-1;
+  box-shadow: 0px 3px 12px 0px rgba(0, 0, 0, 0.16);
+
+  .title {
+    font-size: 15px;
+    font-weight: 700;
+    color: $gray-70;
+    margin-bottom: 5px;
+    text-transform: uppercase;
+  }
+
+  .value {
+    display: block;
+    width: 100%;
+    color: $black;
+  }
+
+  .purchased-seats {
+    font-weight: bold;
+  }
+
+  .number-of-pending {
+    color: red;
+  }
+
+  .separator {
+    width: 2px;
+    height: 50px;
+    background-color: $gray-20;
+  }
+}
+
+.btn-primary .btn-license {
+  color: #fff;
+  text-decoration: none;
+}
+
+@media screen and (max-width: 576px) {
+  .card-container {
+    padding: 0 1.5rem;
+    height: 115px;
+    padding-right: 4rem;
+
+    .title {
+      margin-bottom: 5px;
+    }
+  }
+}

--- a/src/features/Licenses/LicensesPage/_test_/index.test.jsx
+++ b/src/features/Licenses/LicensesPage/_test_/index.test.jsx
@@ -3,6 +3,7 @@ import { waitFor } from '@testing-library/react';
 import LicensesPage from 'features/Licenses/LicensesPage';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -35,7 +36,11 @@ const mockStore = {
 describe('LicensesPage component', () => {
   test('renders licenses data components', () => {
     const component = renderWithProviders(
-      <LicensesPage />,
+      <MemoryRouter initialEntries={['/licenses']}>
+        <Route path="/licenses">
+          <LicensesPage />
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
 

--- a/src/features/Licenses/LicensesPage/index.jsx
+++ b/src/features/Licenses/LicensesPage/index.jsx
@@ -14,7 +14,6 @@ const LicensesPage = () => {
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const stateLicenses = useSelector((state) => state.licenses.table);
   const [currentPage, setCurrentPage] = useState(initialPage);
-
   const handlePagination = (targetPage) => {
     setCurrentPage(targetPage);
     dispatch(updateCurrentPage(targetPage));

--- a/src/features/Licenses/LicensesTable/_test_/index.test.jsx
+++ b/src/features/Licenses/LicensesTable/_test_/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
 
 import LicensesTable from 'features/Licenses/LicensesTable';
 import { columns } from 'features/Licenses/LicensesTable/columns';
@@ -29,7 +30,11 @@ describe('Licenses Table', () => {
     ];
 
     const component = render(
-      <LicensesTable data={data} count={data.length} columns={columns} />,
+      <MemoryRouter initialEntries={['/licenses']}>
+        <Route path="/licenses">
+          <LicensesTable data={data} count={data.length} columns={columns} />
+        </Route>
+      </MemoryRouter>,
     );
 
     // Check if the table rows are present

--- a/src/features/Licenses/LicensesTable/columns.jsx
+++ b/src/features/Licenses/LicensesTable/columns.jsx
@@ -1,7 +1,11 @@
+/* eslint-disable react/prop-types, no-nested-ternary */
+import { Link } from 'react-router-dom';
+
 const columns = [
   {
     Header: 'License Pool',
     accessor: 'licenseName',
+    Cell: ({ row }) => (<Link to={`/licenses/${row.original.licenseId}`} className="link">{row.values.licenseName}</Link>),
   },
   {
     Header: 'Purchased',

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -18,6 +18,7 @@ import LicensesPage from 'features/Licenses/LicensesPage';
 import StudentsPage from 'features/Students/StudentsPage';
 import DashboardPage from 'features/Dashboard/DashboardPage';
 import CoursesDetailPage from 'features/Courses/CoursesDetailPage';
+import LicensesDetailPage from 'features/Licenses/LicensesDetailPage';
 import InstructorsPage from 'features/Instructors/InstructorsPage';
 
 import { fetchInstitutionData } from 'features/Main/data/thunks';
@@ -102,6 +103,9 @@ const Main = () => {
             </Switch>
             <Switch>
               <Route path="/licenses" exact component={LicensesPage} />
+            </Switch>
+            <Switch>
+              <Route path="/licenses/:licenseId" exact component={LicensesDetailPage} />
             </Switch>
             <Switch>
               <Route path="/classes" exact component={ClassesPage} />

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -33,3 +33,10 @@ export const initialPage = 1;
  */
 export const hoursDay = 24;
 export const daysWeek = 7;
+
+/**
+ * URLs.
+ * @readonly
+ * @string
+ */
+export const licenseBuyLink = 'https://www.mindhubpro.com/';


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-988

### Description
Add courses table in license workflow.

### Changes made
- Add Courses Table for License workflow.
- Add test.

### Screenshots
- Figma template

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/1a4c39bf-1404-4bbf-b791-19bb62d4faee)



- Licenses Detail Page

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/bc9241fd-9d8b-4704-b110-2458742f9884)






### How to test

- Clone the Institution Portal MFE
- Go to vue/PADV-988 branch
- Run npm install
- Run npm run start
- Go to http://localhost:1980/licenses
- Click over the name of a License