### PR TITLE
PADV-1048 view all classes functionality

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -11,6 +11,11 @@ import { renderWithProviders } from 'test-utils';
 
 import ClassesFilters from 'features/Classes/ClassesFilters';
 
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({})),
+  useLocation: jest.fn().mockReturnValue({ }),
+}));
+
 let axiosMock;
 
 const courseOption = {

--- a/src/features/Classes/ClassesPage/_test_/index.test.jsx
+++ b/src/features/Classes/ClassesPage/_test_/index.test.jsx
@@ -4,6 +4,11 @@ import { waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
 
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({})),
+  useLocation: jest.fn().mockReturnValue({ }),
+}));
+
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));

--- a/src/features/Classes/ClassesTable/_test_/index.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/index.test.jsx
@@ -4,6 +4,11 @@ import { waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
 
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({})),
+  useLocation: jest.fn().mockReturnValue({ }),
+}));
+
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -1,6 +1,15 @@
 /* eslint-disable react/prop-types, no-nested-ternary */
-import React from 'react';
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { format } from 'date-fns';
+
+import { Button } from 'react-paragon-topaz';
+import AssignInstructors from 'features/Instructors/AssignInstructors';
+
+import { updateClassSelected } from 'features/Instructors/data/slice';
+import { fetchClassesData } from 'features/Classes/data/thunks';
+
+import { initialPage } from 'features/constants';
 
 const columns = [
   {
@@ -36,11 +45,43 @@ const columns = [
   {
     Header: 'Instructors',
     accessor: 'instructors',
-    Cell: ({ row }) => (
-      <ul className="instructors-list">
-        {row.values.instructors && row.values.instructors.map(instructor => <li key={instructor}>{`${instructor}`}</li>)}
-      </ul>
-    ),
+    Cell: ({ row }) => {
+      const [isModalOpen, setIsModalOpen] = useState(false);
+
+      const dispatch = useDispatch();
+      const institution = useSelector((state) => state.main.selectedInstitution);
+
+      const handleOpenModal = () => {
+        dispatch(updateClassSelected(row.original.classId));
+        setIsModalOpen(true);
+      };
+
+      const handleCloseModal = () => {
+        dispatch(fetchClassesData(institution.id, initialPage));
+        setIsModalOpen(false);
+      };
+
+      if (row.values.instructors?.length > 0) {
+        return (
+          <ul className="instructors-list mb-0">
+            {row.values.instructors.map(instructor => <li key={instructor} className="text-truncate">{`${instructor}`}</li>)}
+          </ul>
+        );
+      }
+      return (
+        <>
+          <Button onClick={handleOpenModal} className="button-assign">
+            <i className="fa fa-plus mr-2" />
+            Assign
+          </Button>
+          <AssignInstructors
+            isOpen={isModalOpen}
+            close={handleCloseModal}
+            getClasses={false}
+          />
+        </>
+      );
+    },
   },
 ];
 

--- a/src/features/Classes/data/_test_/redux.test.js
+++ b/src/features/Classes/data/_test_/redux.test.js
@@ -29,7 +29,7 @@ describe('Classes redux tests', () => {
   });
 
   test('successful fetch classes data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?limit=true&institution_id=1&course_name=&instructors=&page=1&`;
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?course_name=`;
     const mockResponse = {
       results: [
         {
@@ -62,7 +62,7 @@ describe('Classes redux tests', () => {
   });
 
   test('failed fetch classes data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?limit=true&institution_id=1&course_name=&instructors=&page=1`;
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     axiosMock.onGet(classesApiUrl)
       .reply(500);
 

--- a/src/features/Classes/data/slice.js
+++ b/src/features/Classes/data/slice.js
@@ -11,6 +11,7 @@ const initialState = {
     numPages: 0,
     count: 0,
   },
+  filters: {},
 };
 
 export const classesSlice = createSlice({
@@ -33,6 +34,9 @@ export const classesSlice = createSlice({
     fetchClassesDataFailed: (state) => {
       state.table.status = RequestStatus.ERROR;
     },
+    updateFilters: (state, { payload }) => {
+      state.filters = payload;
+    },
   },
 });
 
@@ -41,6 +45,7 @@ export const {
   fetchClassesDataRequest,
   fetchClassesDataSuccess,
   fetchClassesDataFailed,
+  updateFilters,
 } = classesSlice.actions;
 
 export const { reducer } = classesSlice;

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -7,13 +7,13 @@ import {
 } from 'features/Classes/data/slice';
 import { getClassesByInstitution } from 'features/Common/data/api';
 
-function fetchClassesData(id, currentPage, courseName = '', urlParamsFilters = '', instructors = '', limit = true) {
+function fetchClassesData(id, currentPage, courseName = '', urlParamsFilters = '', limit = true) {
   return async (dispatch) => {
     dispatch(fetchClassesDataRequest);
 
     try {
       const response = camelCaseObject(
-        await getClassesByInstitution(id, courseName, limit, instructors, currentPage, urlParamsFilters),
+        await getClassesByInstitution(id, courseName, limit, currentPage, urlParamsFilters),
       );
       dispatch(fetchClassesDataSuccess(response.data));
     } catch (error) {

--- a/src/features/Common/data/_test_/api.test.js
+++ b/src/features/Common/data/_test_/api.test.js
@@ -83,7 +83,12 @@ describe('Common api services', () => {
 
     expect(httpClientMock.get).toHaveBeenCalledTimes(1);
     expect(httpClientMock.get).toHaveBeenCalledWith(
-      `${COURSE_OPERATIONS_API_V2}/classes/?limit=false&institution_id=1&course_name=ccx1&instructors=&page=&`,
+      `${COURSE_OPERATIONS_API_V2}/classes/?course_name=ccx1`,
+      {
+        params: {
+          institution_id: 1, limit: false, page: '',
+        },
+      },
     );
   });
 

--- a/src/features/Common/data/api.js
+++ b/src/features/Common/data/api.js
@@ -19,11 +19,17 @@ function getLicensesByInstitution(institutionId, limit, page = 1, urlParamsFilte
   );
 }
 
-function getClassesByInstitution(institutionId, courseName, limit = false, instructorsList = '', page = '', urlParamsFilters = '') {
+function getClassesByInstitution(institutionId, courseName, limit = false, page = '', urlParamsFilters = '') {
   const encodedCourseName = encodeURIComponent(courseName);
+  const params = {
+    limit,
+    institution_id: institutionId,
+    page,
+    ...urlParamsFilters,
+  };
   return getAuthenticatedHttpClient().get(
-    `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/classes`
-    + `/?limit=${limit}&institution_id=${institutionId}&course_name=${encodedCourseName}&instructors=${instructorsList}&page=${page}&${urlParamsFilters}`,
+    `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?course_name=${encodedCourseName}`,
+    { params },
   );
 }
 

--- a/src/features/Dashboard/InstructorAssignSection/index.jsx
+++ b/src/features/Dashboard/InstructorAssignSection/index.jsx
@@ -1,20 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import { Row, Col } from '@edx/paragon';
 import ClassCard from 'features/Dashboard/InstructorAssignSection/ClassCard';
 import { Button } from 'react-paragon-topaz';
 
 import { fetchClassesData } from 'features/Dashboard/data';
+import { updateActiveTab } from 'features/Main/data/slice';
 
 import 'features/Dashboard/InstructorAssignSection/index.scss';
 
 const InstructorAssignSection = () => {
+  const history = useHistory();
   const dispatch = useDispatch();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const classesData = useSelector((state) => state.dashboard.classesNoInstructors.data);
   const [classCards, setClassCards] = useState([]);
   const numberOfClasses = 2;
+
+  const handleViewAllClasses = () => {
+    history.push('/classes?instructors=null');
+    dispatch(updateActiveTab('classes'));
+  };
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
@@ -38,7 +46,7 @@ const InstructorAssignSection = () => {
         {classCards.map(classInfo => <ClassCard data={classInfo} key={classInfo?.classId} />)}
         {classesData.length > numberOfClasses && (
           <div className="d-flex justify-content-center">
-            <Button text className="view-all-btn">View all</Button>
+            <Button text className="view-all-btn" onClick={handleViewAllClasses}>View all</Button>
           </div>
         )}
         {classesData.length === 0 && (

--- a/src/features/Dashboard/data/_test_/redux.test.jsx
+++ b/src/features/Dashboard/data/_test_/redux.test.jsx
@@ -78,8 +78,7 @@ describe('Dashboard redux tests', () => {
   });
 
   test('successful fetch classesNoInstructors data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`
-    + '?limit=false&institution_id=1&course_name=&instructors=null&page=&';
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?course_name=`;
     const mockResponse = [
       {
         classId: 'ccx-v1:demo+demo1+2020+ccx1',
@@ -109,8 +108,7 @@ describe('Dashboard redux tests', () => {
   });
 
   test('failed fetch classesNoInstructors data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`
-    + '?limit=false&institution_id=1&course_name=&instructors=null';
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     axiosMock.onGet(classesApiUrl)
       .reply(500);
 
@@ -127,8 +125,7 @@ describe('Dashboard redux tests', () => {
   });
 
   test('successful fetch classes data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`
-    + '?limit=false&institution_id=1&course_name=&instructors=&page=&';
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?course_name=`;
     const mockResponse = [
       {
         classId: 'ccx-v1:demo+demo1+2020+ccx1',
@@ -158,8 +155,7 @@ describe('Dashboard redux tests', () => {
   });
 
   test('failed fetch classes data', async () => {
-    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`
-    + '?limit=false&institution_id=1&course_name=&instructors=';
+    const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     axiosMock.onGet(classesApiUrl)
       .reply(500);
 

--- a/src/features/Dashboard/data/thunks.js
+++ b/src/features/Dashboard/data/thunks.js
@@ -36,7 +36,8 @@ function fetchClassesData(id, hasInstructors = false) {
         const response = camelCaseObject(await getClassesByInstitution(id, '', false));
         dispatch(fetchClassesDataSuccess(response.data));
       } else {
-        const response = camelCaseObject(await getClassesByInstitution(id, '', false, 'null'));
+        const instructorsNull = { instructors: 'null' };
+        const response = camelCaseObject(await getClassesByInstitution(id, '', false, '', instructorsNull));
         dispatch(fetchClassesNoInstructorsDataSuccess(response.data));
       }
     } catch (error) {

--- a/src/features/Students/data/_test_/redux.test.js
+++ b/src/features/Students/data/_test_/redux.test.js
@@ -131,7 +131,7 @@ describe('Students redux tests', () => {
   });
 
   test('successful fetch classes data', async () => {
-    const studentsApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?limit=false&institution_id=1&course_name=Demo&instructors=&page=&`;
+    const studentsApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?course_name=Demo`;
     const mockResponse = [
       {
         classId: 'ccx-v1:demo+demo1+2020+ccx@2',
@@ -155,7 +155,7 @@ describe('Students redux tests', () => {
   });
 
   test('failed fetch classes data', async () => {
-    const studentsApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/?limit=false&institution_id=1&course_name=Demo&instructors=`;
+    const studentsApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     axiosMock.onGet(studentsApiUrl)
       .reply(500);
 


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1048

### Description
Add view all classes button in home page functionality

### Changes made
Add query param to instructors null when click on button
Adjust filters to handle instructors null from query and filters in pagination
Add assign modal in class table when instructors is null
Update test

### Screenshots
![Screenshot from 2024-03-14 15-56-25](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/36944773/71aebb23-e25f-43cb-b90b-c9cf7ce26007)

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/dashboard