### PR TITLE
PADV-1111 - Class redirection in Students view and Classes view

### DIFF
--- a/src/features/Classes/ClassesPage/_test_/index.test.jsx
+++ b/src/features/Classes/ClassesPage/_test_/index.test.jsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import ClassesPage from 'features/Classes/ClassesPage';
 import { waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
 
-jest.mock('react-router-dom', () => ({
-  useParams: jest.fn(() => ({})),
-  useLocation: jest.fn().mockReturnValue({ }),
-}));
-
-jest.mock('@edx/frontend-platform/logging', () => ({
-  logError: jest.fn(),
-}));
+import ClassesPage from 'features/Classes/ClassesPage';
+import { columns } from 'features/Classes/ClassesTable/columns';
 
 const mockStore = {
   classes: {
@@ -46,7 +40,15 @@ const mockStore = {
 describe('ClassesPage', () => {
   it('renders classes data and pagination', async () => {
     const component = renderWithProviders(
-      <ClassesPage />,
+      <MemoryRouter initialEntries={['/classes']}>
+        <Route path="/classes">
+          <ClassesPage
+            data={mockStore.classes.table.data}
+            count={mockStore.classes.table.data.length}
+            columns={columns}
+          />
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
 

--- a/src/features/Classes/ClassesTable/_test_/index.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/index.test.jsx
@@ -1,71 +1,79 @@
 import React from 'react';
-import ClassesPage from 'features/Classes/ClassesPage';
-import { waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
 
-jest.mock('react-router-dom', () => ({
-  useParams: jest.fn(() => ({})),
-  useLocation: jest.fn().mockReturnValue({ }),
-}));
+import ClassesTable from 'features/Classes/ClassesTable';
+import { columns } from 'features/Classes/ClassesTable/columns';
 
-jest.mock('@edx/frontend-platform/logging', () => ({
-  logError: jest.fn(),
-}));
+describe('Classes Table', () => {
+  test('Should render the table without data', () => {
+    render(<ClassesTable data={[]} count={0} columns={[]} />);
+    const emptyTableText = screen.getByText('No classes found.');
+    expect(emptyTableText).toBeInTheDocument();
+  });
 
-const mockStore = {
-  classes: {
-    table: {
-      data: [
-        {
-          masterCourseName: 'Demo MasterCourse 1',
-          className: 'Demo Class 1',
-          startDate: '09/21/24',
-          endDate: null,
-          min: 50,
-          numberOfStudents: 1,
-          maxStudents: 100,
-          instructors: ['instructor_1'],
+  test('Should render the table with data', () => {
+    const mockStore = {
+      classes: {
+        table: {
+          data: [
+            {
+              masterCourseName: 'Demo MasterCourse 1',
+              className: 'Demo Class 1',
+              startDate: '09/21/24',
+              endDate: null,
+              minStudentsAllowed: 50,
+              numberOfStudents: 1,
+              maxStudents: 100,
+              instructors: ['instructor_1'],
+            },
+            {
+              masterCourseName: 'Demo MasterCourse 2',
+              className: 'Demo Class 2',
+              startDate: '09/21/25',
+              endDate: null,
+              minStudentsAllowed: 200,
+              numberOfStudents: 2,
+              maxStudents: 10,
+              instructors: ['instructor_2', 'instructor_3'],
+            },
+          ],
+          count: 2,
+          num_pages: 1,
+          current_page: 1,
         },
-        {
-          masterCourseName: 'Demo MasterCourse 2',
-          className: 'Demo Class 2',
-          startDate: '09/21/25',
-          endDate: null,
-          min: 200,
-          numberOfStudents: 1,
-          maxStudents: 10,
-          instructors: ['instructor_2', 'instructor_3'],
-        },
-      ],
-      count: 2,
-      num_pages: 1,
-      current_page: 1,
-    },
-  },
-};
+      },
+    };
 
-describe('ClassesPage', () => {
-  it('renders classes data and pagination', async () => {
     const component = renderWithProviders(
-      <ClassesPage />,
+      <MemoryRouter initialEntries={['/classes']}>
+        <Route path="/classes">
+          <ClassesTable
+            data={mockStore.classes.table.data}
+            count={mockStore.classes.table.data.length}
+            columns={columns}
+          />
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
 
-    waitFor(() => {
-      expect(component.container).toHaveTextContent('Demo MasterCourse 1');
-      expect(component.container).toHaveTextContent('Demo MasterCourse 2');
-      expect(component.container).toHaveTextContent('Demo Class 1');
-      expect(component.container).toHaveTextContent('Demo Class 2');
-      expect(component.container).toHaveTextContent('09/21/24');
-      expect(component.container).toHaveTextContent('09/21/25');
-      expect(component.container).toHaveTextContent('50');
-      expect(component.container).toHaveTextContent('200');
-      expect(component.container).toHaveTextContent('100');
-      expect(component.container).toHaveTextContent('10');
-      expect(component.container).toHaveTextContent('instructor_1');
-      expect(component.container).toHaveTextContent('instructor_2');
-      expect(component.container).toHaveTextContent('instructor_3');
-    });
+    expect(component.container).toHaveTextContent('Demo MasterCourse 1');
+    expect(component.container).toHaveTextContent('Demo MasterCourse 2');
+    expect(component.container).toHaveTextContent('Demo Class 1');
+    expect(component.container).toHaveTextContent('Demo Class 2');
+    expect(component.container).toHaveTextContent('09/21/24');
+    expect(component.container).toHaveTextContent('09/21/25');
+    expect(component.container).toHaveTextContent('50');
+    expect(component.container).toHaveTextContent('200');
+    expect(component.container).toHaveTextContent('1');
+    expect(component.container).toHaveTextContent('2');
+    expect(component.container).toHaveTextContent('100');
+    expect(component.container).toHaveTextContent('10');
+    expect(component.container).toHaveTextContent('instructor_1');
+    expect(component.container).toHaveTextContent('instructor_2');
+    expect(component.container).toHaveTextContent('instructor_3');
   });
 });

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
 
 import { Button } from 'react-paragon-topaz';
 import AssignInstructors from 'features/Instructors/AssignInstructors';
@@ -19,6 +20,14 @@ const columns = [
   {
     Header: 'Class',
     accessor: 'className',
+    Cell: ({ row }) => (
+      <Link
+        to={`/courses/${row.values.masterCourseName}/${row.values.className}?classId=${row.original.classId}`}
+        className="text-truncate link"
+      >
+        {row.values.className}
+      </Link>
+    ),
   },
   {
     Header: 'Start Date',

--- a/src/features/Students/StudentsPage/_test_/index.test.jsx
+++ b/src/features/Students/StudentsPage/_test_/index.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import StudentsPage from 'features/Students/StudentsPage';
 import { waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { renderWithProviders } from 'test-utils';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -71,7 +72,11 @@ const mockStore = {
 describe('StudentsPage', () => {
   it('renders students data and pagination', async () => {
     const component = renderWithProviders(
-      <StudentsPage />,
+      <MemoryRouter initialEntries={['/sudents']}>
+        <Route path="/students">
+          <StudentsPage />,
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
 

--- a/src/features/Students/StudentsTable/_test_/index.test.jsx
+++ b/src/features/Students/StudentsTable/_test_/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { StudentsTable } from 'features/Students/StudentsTable';
 import { getColumns } from 'features/Students/StudentsTable/columns';
@@ -50,9 +51,13 @@ describe('Student Table', () => {
     ];
 
     const component = render(
-      <Provider store={store}>
-        <StudentsTable data={data} count={data.length} columns={getColumns()} />
-      </Provider>,
+      <MemoryRouter initialEntries={['/students']}>
+        <Route path="/students">
+          <Provider store={store}>
+            <StudentsTable data={data} count={data.length} columns={getColumns()} />
+          </Provider>,
+        </Route>
+      </MemoryRouter>,
     );
 
     const tableRows = screen.getAllByRole('row');

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { format } from 'date-fns';
 import { ProgressBar } from '@edx/paragon';
+import { Link } from 'react-router-dom';
 
 const getColumns = () => [
   {
@@ -14,6 +15,14 @@ const getColumns = () => [
   {
     Header: 'Class Name',
     accessor: 'className',
+    Cell: ({ row }) => (
+      <Link
+        to={`/courses/${row.original.courseName}/${row.values.className}?classId=${row.original.classId}`}
+        className="text-truncate link"
+      >
+        {row.values.className}
+      </Link>
+    ),
   },
   {
     Header: 'Class Id',


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1111

### Description
Add link in class column in Students View and in Clases Table to open the Class detail page.

### Changes made
- Add link to Class detail in Students View.
- Add link to Class detail in Classes View.
- Update tests.

### Screenshots
- Students Table

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/f938730f-8dc5-4491-ac55-8b3291f260ac)


- Classes Table

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/2cfdf9af-1626-46f2-a7cb-9d6c67edae2b)

### How to test

- Clone the Institution Portal MFE
- Go to vue/PADV-1111 branch
- Run npm install
- Run npm run start
- Go to http://localhost:1980/classes and verify the link in class column.
- Go to http://localhost:1980/students and verify the link in class name column.