### PR TITLE
PADV-974 - Add classes table in instructors workflow

### DIFF
--- a/src/features/Classes/data/slice.js
+++ b/src/features/Classes/data/slice.js
@@ -18,6 +18,9 @@ export const classesSlice = createSlice({
   name: 'classes',
   initialState,
   reducers: {
+    resetClassesTable: (state) => {
+      state.table = initialState.table;
+    },
     updateCurrentPage: (state, { payload }) => {
       state.table.currentPage = payload;
     },
@@ -41,6 +44,7 @@ export const classesSlice = createSlice({
 });
 
 export const {
+  resetClassesTable,
   updateCurrentPage,
   fetchClassesDataRequest,
   fetchClassesDataSuccess,

--- a/src/features/Instructors/InstructorDetailTable/_test_/columns.test.jsx
+++ b/src/features/Instructors/InstructorDetailTable/_test_/columns.test.jsx
@@ -1,0 +1,27 @@
+import { columns } from 'features/Instructors/InstructorDetailTable/columns';
+
+describe('columns', () => {
+  test('returns an array of columns with correct properties', () => {
+    expect(columns).toBeInstanceOf(Array);
+    expect(columns).toHaveLength(4);
+
+    const [
+      classColumn,
+      courseColumn,
+      startEndDateColumn,
+      statusColumn,
+    ] = columns;
+
+    expect(classColumn).toHaveProperty('Header', 'Class');
+    expect(classColumn).toHaveProperty('accessor', 'className');
+
+    expect(courseColumn).toHaveProperty('Header', 'Course');
+    expect(courseColumn).toHaveProperty('accessor', 'masterCourseName');
+
+    expect(startEndDateColumn).toHaveProperty('Header', 'Start - End Date');
+    expect(startEndDateColumn).toHaveProperty('accessor', 'startDate');
+
+    expect(statusColumn).toHaveProperty('Header', 'Status');
+    expect(statusColumn).toHaveProperty('accessor', 'status');
+  });
+});

--- a/src/features/Instructors/InstructorDetailTable/columns.jsx
+++ b/src/features/Instructors/InstructorDetailTable/columns.jsx
@@ -1,0 +1,46 @@
+/* eslint-disable react/prop-types, no-nested-ternary */
+import React from 'react';
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { Badge } from 'react-paragon-topaz';
+
+import { ClassStatus, badgeVariants } from 'features/constants';
+
+const columns = [
+  {
+    Header: 'Class',
+    accessor: 'className',
+    Cell: ({ row }) => (
+      <Link
+        to={`/courses/${row.values.masterCourseName}/${row.values.className}?classId=${row.original.classId}`}
+        className="link"
+      >
+        {row.values.className}
+      </Link>
+    ),
+  },
+  {
+    Header: 'Course',
+    accessor: 'masterCourseName',
+  },
+  {
+    Header: 'Start - End Date',
+    accessor: 'startDate',
+    Cell: ({ row }) => {
+      const startDate = row.values.startDate ? format(row.values.startDate, 'MM/dd/yy') : '';
+      const endDate = row.original.endDate ? format(row.original.endDate, 'MM/dd/yy') : '';
+      return <div>{startDate} - {endDate}</div>;
+    },
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    Cell: ({ row }) => (
+      <Badge variant={badgeVariants[row.values.status?.toLowerCase()] || 'success'} light className="text-capitalize">
+        {ClassStatus[row.values.status]}
+      </Badge>
+    ),
+  },
+];
+
+export { columns };

--- a/src/features/Instructors/InstructorsDetailPage/_test_/index.test.jsx
+++ b/src/features/Instructors/InstructorsDetailPage/_test_/index.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+import InstructorsDetailPage from 'features/Instructors/InstructorsDetailPage';
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const mockStore = {
+  main: {
+    selectedInstitution: {
+      id: 1,
+      name: 'Institution 1',
+      shortName: 'Test',
+      active: true,
+      externalId: '',
+      created: '2023-06-22T22:48:56.124907Z',
+      modified: '2023-06-22T22:48:56.124907Z',
+      label: 'Institution 1',
+      value: 1,
+    },
+  },
+  classes: {
+    table: {
+      data: [
+        {
+          className: 'Demo Class 1',
+          masterCourseName: 'Demo MaterCourse 1',
+          startDate: '08/15/23',
+          endDate: '08/15/26',
+          status: 'pending',
+        },
+        {
+          className: 'Demo Class 2',
+          masterCourseName: 'Demo MaterCourse 2',
+          startDate: '08/15/24',
+          endDate: '08/15/27',
+          status: 'complete',
+        },
+        {
+          className: 'Demo Class 3',
+          masterCourseName: 'Demo MaterCourse 3',
+          startDate: '08/15/20',
+          endDate: '08/15/22',
+          status: 'in progress',
+        },
+      ],
+      count: 3,
+      num_pages: 1,
+      current_page: 1,
+    },
+  },
+  instructors: {
+    table: {
+      data: [
+        {
+          instructorUsername: 'instructor',
+          instructorName: 'Instructor 1',
+          instructorEmail: 'instructor1@example.com',
+          ccxId: 'CCX1',
+          ccxName: 'CCX 1',
+        },
+      ],
+      count: 1,
+      num_pages: 1,
+      current_page: 1,
+    },
+  },
+};
+
+describe('InstructorsDetailPage', () => {
+  test('renders classes data and pagination', async () => {
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/instructors/instructor']}>
+        <Route path="/instructors/:instructorUsername">
+          <InstructorsDetailPage />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    waitFor(() => {
+      expect(component.container).toHaveTextContent('Demo Class 1');
+      expect(component.container).toHaveTextContent('Demo Class 2');
+      expect(component.container).toHaveTextContent('Demo Class 3');
+      expect(component.container).toHaveTextContent('Demo MaterCourse 1');
+      expect(component.container).toHaveTextContent('Demo MaterCourse 2');
+      expect(component.container).toHaveTextContent('Demo MaterCourse 3');
+      expect(component.container).toHaveTextContent('08/15/23 - 08/15/26');
+      expect(component.container).toHaveTextContent('08/15/24 - 08/15/27');
+      expect(component.container).toHaveTextContent('08/15/20 - 08/15/22');
+      expect(component.container).toHaveTextContent('pending');
+      expect(component.container).toHaveTextContent('complete');
+      expect(component.container).toHaveTextContent('in progress');
+    });
+  });
+});

--- a/src/features/Instructors/InstructorsDetailPage/index.jsx
+++ b/src/features/Instructors/InstructorsDetailPage/index.jsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Link, useParams, useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Container,
+  Pagination,
+  Tabs,
+  Tab,
+} from '@edx/paragon';
+import Table from 'features/Main/Table';
+import { fetchClassesData } from 'features/Classes/data/thunks';
+import { resetClassesTable, updateCurrentPage } from 'features/Classes/data/slice';
+import { fetchInstructorsData } from 'features/Instructors/data/thunks';
+import { columns } from 'features/Instructors/InstructorDetailTable/columns';
+import { initialPage } from 'features/constants';
+
+import 'features/Instructors/InstructorsDetailPage/index.scss';
+
+const InstructorsDetailPage = () => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const { instructorUsername } = useParams();
+
+  const institutionRef = useRef(undefined);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+
+  const defaultInstructorInfo = {
+    instructorUsername: '',
+    instructorName: '',
+  };
+
+  const institution = useSelector((state) => state.main.selectedInstitution);
+  const classes = useSelector((state) => state.classes.table);
+  const instructorInfo = useSelector((state) => state.instructors.table.data)
+    .find((instructor) => instructor?.instructorUsername === instructorUsername) || defaultInstructorInfo;
+
+  const handlePagination = (targetPage) => {
+    setCurrentPage(targetPage);
+    dispatch(updateCurrentPage(targetPage));
+  };
+
+  useEffect(() => {
+    if (institution.id) {
+      dispatch(fetchClassesData(institution.id, initialPage, '', { instructor: instructorInfo.instructorUsername }));
+      dispatch(fetchInstructorsData(institution.id, initialPage, instructorInfo.instructorUsername));
+    }
+
+    return () => {
+      dispatch(resetClassesTable());
+    };
+  }, [dispatch, institution.id, instructorInfo.instructorUsername]);
+
+  useEffect(() => {
+    dispatch(fetchClassesData(institution.id, currentPage, '', { instructor: instructorInfo.instructorUsername }));
+  }, [currentPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (institution.id !== undefined && institutionRef.current === undefined) {
+      institutionRef.current = institution.id;
+    }
+
+    if (institution.id !== institutionRef.current) {
+      history.push('/instructors');
+    }
+  }, [institution, history]);
+
+  return (
+    <Container size="xl" className="px-4 mt-3">
+      <div className="d-flex justify-content-between mb-3 flex-column flex-sm-row">
+        <div className="d-flex align-items-center mb-3">
+          <Link to="/instructors" className="mr-3 link">
+            <i className="fa-solid fa-arrow-left" />
+          </Link>
+          <h3 className="h2 mb-0 course-title">{instructorInfo.instructorName}</h3>
+        </div>
+      </div>
+
+      <Tabs variant="tabs" defaultActiveKey="classes" id="uncontrolled-tab-example">
+        <Tab eventKey="classes" title="Classes" />
+      </Tabs>
+
+      <Table columns={columns} count={classes.count} data={classes.data} text="No classes found." />
+      {classes.numPages > initialPage && (
+      <Pagination
+        paginationLabel="paginationNavigation"
+        pageCount={classes.numPages}
+        currentPage={currentPage}
+        onPageSelect={handlePagination}
+        variant="reduced"
+        className="mx-auto pagination-table"
+        size="small"
+      />
+      )}
+    </Container>
+  );
+};
+
+export default InstructorsDetailPage;

--- a/src/features/Instructors/InstructorsDetailPage/index.scss
+++ b/src/features/Instructors/InstructorsDetailPage/index.scss
@@ -1,0 +1,9 @@
+.pgn__data-table-layout-wrapper {
+  padding-top: 17px;
+}
+
+.nav-tabs .nav-link.active,
+.nav-tabs .nav-item.show .nav-link {
+  text-decoration: none;
+  font-weight: 700;
+}

--- a/src/features/Instructors/InstructorsPage/_test_/index.test.jsx
+++ b/src/features/Instructors/InstructorsPage/_test_/index.test.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { waitFor } from '@testing-library/react';
-import InstructorsPage from 'features/Instructors/InstructorsPage';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+import InstructorsPage from 'features/Instructors/InstructorsPage';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -43,7 +45,11 @@ const mockStore = {
 describe('InstructorPage', () => {
   test('render instructor page', () => {
     const component = renderWithProviders(
-      <InstructorsPage />,
+      <MemoryRouter initialEntries={['/instructors']}>
+        <Route path="/instructors">
+          <InstructorsPage />
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
 

--- a/src/features/Instructors/InstructorsTable/_test_/index.test.jsx
+++ b/src/features/Instructors/InstructorsTable/_test_/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { renderWithProviders } from 'test-utils';
 
 import InstructorsTable from 'features/Instructors/InstructorsTable';
@@ -34,7 +35,11 @@ describe('Instructor Table', () => {
     ];
 
     const component = renderWithProviders(
-      <InstructorsTable data={data} count={data.length} columns={columns} />,
+      <MemoryRouter initialEntries={['/instructors']}>
+        <Route path="/instructors">
+          <InstructorsTable data={data} count={data.length} columns={columns} />
+        </Route>
+      </MemoryRouter>,
     );
 
     // Check if the table rows are present

--- a/src/features/Instructors/InstructorsTable/columns.jsx
+++ b/src/features/Instructors/InstructorsTable/columns.jsx
@@ -1,11 +1,21 @@
 /* eslint-disable react/prop-types, no-nested-ternary */
 import { differenceInHours, differenceInDays, differenceInWeeks } from 'date-fns';
+import { Link } from 'react-router-dom';
+
 import { daysWeek, hoursDay } from 'features/constants';
 
 const columns = [
   {
     Header: 'Instructor',
     accessor: 'instructorName',
+    Cell: ({ row }) => (
+      <Link
+        to={`/instructors/${row.original.instructorUsername}`}
+        className="link"
+      >
+        {row.values.instructorName}
+      </Link>
+    ),
   },
   {
     Header: 'Last seen',

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -20,6 +20,7 @@ import DashboardPage from 'features/Dashboard/DashboardPage';
 import CoursesDetailPage from 'features/Courses/CoursesDetailPage';
 import LicensesDetailPage from 'features/Licenses/LicensesDetailPage';
 import InstructorsPage from 'features/Instructors/InstructorsPage';
+import InstructorsDetailPage from 'features/Instructors/InstructorsDetailPage';
 
 import { fetchInstitutionData } from 'features/Main/data/thunks';
 import { updateSelectedInstitution } from 'features/Main/data/slice';
@@ -91,6 +92,9 @@ const Main = () => {
             </Switch>
             <Switch>
               <Route path="/instructors" exact component={InstructorsPage} />
+            </Switch>
+            <Switch>
+              <Route path="/instructors/:instructorUsername" exact component={InstructorsDetailPage} />
             </Switch>
             <Switch>
               <Route path="/courses" exact component={CoursesPage} />

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -40,3 +40,25 @@ export const daysWeek = 7;
  * @string
  */
 export const licenseBuyLink = 'https://www.mindhubpro.com/';
+
+/**
+ * Constants status.
+ * @readonly
+ * @enum {string}
+ */
+export const ClassStatus = {
+  in_progress: 'In progress',
+  complete: 'Complete',
+  pending: 'Pending',
+};
+
+/**
+ * Badge Variants.
+ * @readonly
+ * @enum {string}
+ */
+export const badgeVariants = {
+  in_progress: 'primary',
+  complete: 'success',
+  pending: 'warning',
+};


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-974

### Description
Add classes table in instructors workflow.

### Changes made
- Add InstructorsDetailPage.
- Add InstructorDetailTable.
- Add tests.

**IMPORTANT**: The progress bar (% exam ready) is not part of this scope, nor Profile and Availability tabs.

### Screenshots
- Classes Table (Figma)

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/ae3bbf8a-364e-4bc9-982b-01d689154a35)


- Classes Table

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/9bb9351f-02f9-428a-9bf1-cf72d7b72478)






### How to test

- Clone the Institution Portal MFE.
- Go to vue/PADV-974 branch.
- Run npm install.
- Run npm run start.
- Go to http://localhost:1980/instructors and verify the link in instructor column.
- Click over an instructor name and verify classes table.
- Click over a class name and verify if the link redirect you to the class detail page.