### PR TITLE
Fix: Implement Botton component correctly

### DIFF
--- a/src/features/Licenses/LicensesDetailPage/index.jsx
+++ b/src/features/Licenses/LicensesDetailPage/index.jsx
@@ -98,8 +98,14 @@ const LicensesDetailPage = () => {
       </div>
       <div className="license-page-content-container">
         <div className="flex-end">
-          <Button type="button">
-            <a className="btn-license" href={licenseBuyLink} target="_blank" rel="noreferrer">Buy a license</a>
+          <Button
+            as="a"
+            href={licenseBuyLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-decoration-none text-white"
+          >
+            Buy a license
           </Button>
         </div>
         <Table columns={columns} data={coursesTable.data} count={coursesTable.count} text="No courses found." />

--- a/src/features/Licenses/LicensesDetailPage/index.scss
+++ b/src/features/Licenses/LicensesDetailPage/index.scss
@@ -57,11 +57,6 @@
   }
 }
 
-.btn-primary .btn-license {
-  color: #fff;
-  text-decoration: none;
-}
-
 @media screen and (max-width: 576px) {
   .card-container {
     padding: 0 1.5rem;


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-988

### Description
We realized that the behavior of the botton is not correctly since you have to click only over the text (Buy a license) to go to [mindhub pro](https://www.mindhubpro.com/).

### Changes made
- Change license botton.

### Screenshots

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/73655023/e1ad268c-9dc3-4882-8005-454c41680b6e)







### How to test

- Clone the Institution Portal MFE.
- Go to sergio/fix-license-btn branch.
- Run npm install.
- Run npm run start.
- Go to http://localhost:1980/licenses.
- Click over a license name.
- **Verify if the license button works as expected.**
- Click the button and verify if it redirect you to [mindhub pro](https://www.mindhubpro.com/).