### PR TITLE
Chore - add LMS_BASE_URL obtaining instructor image.

### DIFF
--- a/src/features/Classes/InstructorCard/index.jsx
+++ b/src/features/Classes/InstructorCard/index.jsx
@@ -6,6 +6,7 @@ import { formatDateRange } from 'helpers';
 import { initialPage } from 'features/constants';
 import { updateInstructorOptions } from 'features/Instructors/data/slice';
 import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
+import { getConfig } from '@edx/frontend-platform';
 
 import instructorDefaultImage from 'assets/avatar.svg';
 
@@ -68,7 +69,11 @@ const InstructorCard = () => {
         <h4 className="text-color text-uppercase mb-3 h5">Instructor</h4>
         <div className="d-flex align-items-center">
           <img
-            src={instructors[0]?.instructorImage ? instructors[0]?.instructorImage : instructorDefaultImage}
+            src={
+              instructors[0]?.instructorImage
+                ? getConfig().LMS_BASE_URL + (instructors[0]?.instructorImage || '')
+                : instructorDefaultImage
+            }
             alt="Instructor profile"
             className="instructor-image"
           />


### PR DESCRIPTION
## Description

The instructors endpoint returns just the path without the LMS_BASE_URL so in this PR the setting it's added via getConfig.

## Changes Made
- [x] Add getConfig().LMS_BASE_URL.

### Before

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/ecfd8d4d-754b-4e9f-9c94-77a37b67620e)

### After

![image](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/30726391/d5588fec-0ef7-4dc4-8b37-e6340cffd876)
