### PR TITLE
fix: top shadow in tables

### DIFF
--- a/src/features/Instructors/InstructorsDetailPage/index.jsx
+++ b/src/features/Instructors/InstructorsDetailPage/index.jsx
@@ -75,7 +75,7 @@ const InstructorsDetailPage = () => {
         </div>
       </div>
 
-      <Tabs variant="tabs" defaultActiveKey="classes" id="uncontrolled-tab-example">
+      <Tabs variant="tabs" defaultActiveKey="classes" id="uncontrolled-tab-example" className="mb-3">
         <Tab eventKey="classes" title="Classes" />
       </Tabs>
 

--- a/src/features/Instructors/InstructorsDetailPage/index.scss
+++ b/src/features/Instructors/InstructorsDetailPage/index.scss
@@ -1,7 +1,3 @@
-.pgn__data-table-layout-wrapper {
-  padding-top: 17px;
-}
-
 .nav-tabs .nav-link.active,
 .nav-tabs .nav-item.show .nav-link {
   text-decoration: none;


### PR DESCRIPTION
# Description
This PR fixes the weird shadow that appears in the most of the tables, this visual error is more clear if the table is empty.

# Changes Made
- removed extra padding for tables.
- added bootstrap margin class for tab.


## Screenshots

### Before
![b](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/908c0eb8-8e6b-4efb-b18e-b77c05f46dd9)

### After

![a2](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/932aa305-157f-4213-8c48-8c3d3d06b497)

![a](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/f8339972-c092-49ee-b2c2-15ccd87dd55f)



