### PR TITLE
feat: mailto in emails

### DIFF
--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -24,6 +24,14 @@ const columns = [
   {
     Header: 'Email',
     accessor: 'learnerEmail',
+    Cell: ({ row }) => (
+      <a
+        href={`mailto:${row.values.learnerEmail}`}
+        className="link"
+      >
+        {row.values.learnerEmail}
+      </a>
+    ),
   },
   {
     Header: 'Status',

--- a/src/features/Instructors/InstructorsTable/columns.jsx
+++ b/src/features/Instructors/InstructorsTable/columns.jsx
@@ -39,6 +39,14 @@ const columns = [
   {
     Header: 'Email',
     accessor: 'instructorEmail',
+    Cell: ({ row }) => (
+      <a
+        href={`mailto:${row.values.instructorEmail}`}
+        className="link"
+      >
+        {row.values.instructorEmail}
+      </a>
+    ),
   },
   {
     Header: 'Courses Taught',

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -11,6 +11,14 @@ const columns = [
   {
     Header: 'Email',
     accessor: 'learnerEmail',
+    Cell: ({ row }) => (
+      <a
+        href={`mailto:${row.values.learnerEmail}`}
+        className="link"
+      >
+        {row.values.learnerEmail}
+      </a>
+    ),
   },
   {
     Header: 'Class Name',


### PR DESCRIPTION
# Description

This PR adds the [mailto](https://css-tricks.com/snippets/html/mailto-links/) in email columns.

This PR resolves [PADV-1112](https://agile-jira.pearson.com/browse/PADV-1112)

## Change log
- Added mailto in columns.


## Screenshots
### Before
![2](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/474aa59e-c4c6-49ec-b919-bdb0755670da)


### After
![1](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/37c73467-0ad5-4175-be2f-8ed66e5d4b79)


### How to test

Clone the Institution Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to:

- http://localhost:1980/instructors
- http://localhost:1980/students
- http://localhost:1980/courses/:courseId/:classId

and see the result.

