### PR TITLE
fix: Sidebar router selection

### DIFF
--- a/src/features/Main/ActiveTabUpdater/index.jsx
+++ b/src/features/Main/ActiveTabUpdater/index.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+
+import { updateActiveTab } from 'features/Main/data/slice';
+
+const ActiveTabUpdater = ({ children, path }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const currentTab = path?.split('/')[1] || 'dashboard';
+    dispatch(updateActiveTab(currentTab));
+  }, [dispatch, path]);
+
+  return children;
+};
+
+ActiveTabUpdater.propTypes = {
+  path: PropTypes.string.isRequired,
+};
+
+export default ActiveTabUpdater;

--- a/src/features/Main/__test__/index.test.jsx
+++ b/src/features/Main/__test__/index.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { updateActiveTab } from 'features/Main/data/slice';
+import ActiveTabUpdater from 'features/Main/ActiveTabUpdater';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+describe('ActiveTabUpdater', () => {
+  beforeEach(() => {
+    useDispatch.mockClear();
+  });
+
+  test('Should dispatch updateActiveTab action on mount', () => {
+    const dispatchMock = jest.fn();
+    useDispatch.mockReturnValue(dispatchMock);
+
+    render(
+      <ActiveTabUpdater path="/test">
+        <div>Child component</div>
+      </ActiveTabUpdater>,
+    );
+
+    const childComponent = screen.getByText('Child component');
+    expect(dispatchMock).toHaveBeenCalledWith(updateActiveTab('test'));
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(childComponent).toBeInTheDocument();
+  });
+
+  test('Should dispatch updateActiveTab with default value', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const dispatchMock = jest.fn();
+    useDispatch.mockReturnValue(dispatchMock);
+
+    render(
+      <ActiveTabUpdater>
+        <div>Child component</div>
+      </ActiveTabUpdater>,
+    );
+
+    const childComponent = screen.getByText('Child component');
+    expect(dispatchMock).toHaveBeenCalledWith(updateActiveTab('dashboard'));
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(childComponent).toBeInTheDocument();
+  });
+});

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -21,6 +21,7 @@ import CoursesDetailPage from 'features/Courses/CoursesDetailPage';
 import LicensesDetailPage from 'features/Licenses/LicensesDetailPage';
 import InstructorsPage from 'features/Instructors/InstructorsPage';
 import InstructorsDetailPage from 'features/Instructors/InstructorsDetailPage';
+import ActiveTabUpdater from 'features/Main//ActiveTabUpdater';
 
 import { fetchInstitutionData } from 'features/Main/data/thunks';
 import { updateSelectedInstitution } from 'features/Main/data/slice';
@@ -48,6 +49,19 @@ const Main = () => {
       dispatch(updateSelectedInstitution(options[0]));
     }
   }, [stateInstitutions, dispatch]);
+
+  const routes = [
+    { path: '/dashboard', component: DashboardPage, exact: true },
+    { path: '/students', component: StudentsPage, exact: true },
+    { path: '/instructors', component: InstructorsPage, exact: true },
+    { path: '/instructors/:instructorUsername', component: InstructorsDetailPage, exact: true },
+    { path: '/courses', component: CoursesPage, exact: true },
+    { path: '/courses/:courseId', component: CoursesDetailPage, exact: true },
+    { path: '/courses/:courseId/:classId', component: ClassPage, exact: true },
+    { path: '/licenses', component: LicensesPage, exact: true },
+    { path: '/licenses/:licenseId', component: LicensesDetailPage, exact: true },
+    { path: '/classes', component: ClassesPage, exact: true },
+  ];
 
   return (
     <BrowserRouter basename={getConfig().INSTITUTION_PORTAL_PATH}>
@@ -83,36 +97,18 @@ const Main = () => {
               <Route exact path="/">
                 <Redirect to="/dashboard" />
               </Route>
-            </Switch>
-            <Switch>
-              <Route path="/dashboard" exact component={DashboardPage} />
-            </Switch>
-            <Switch>
-              <Route path="/students" exact component={StudentsPage} />
-            </Switch>
-            <Switch>
-              <Route path="/instructors" exact component={InstructorsPage} />
-            </Switch>
-            <Switch>
-              <Route path="/instructors/:instructorUsername" exact component={InstructorsDetailPage} />
-            </Switch>
-            <Switch>
-              <Route path="/courses" exact component={CoursesPage} />
-            </Switch>
-            <Switch>
-              <Route path="/courses/:courseId" exact component={CoursesDetailPage} />
-            </Switch>
-            <Switch>
-              <Route path="/courses/:courseId/:classId" exact component={ClassPage} />
-            </Switch>
-            <Switch>
-              <Route path="/licenses" exact component={LicensesPage} />
-            </Switch>
-            <Switch>
-              <Route path="/licenses/:licenseId" exact component={LicensesDetailPage} />
-            </Switch>
-            <Switch>
-              <Route path="/classes" exact component={ClassesPage} />
+              {routes.map(({ path, exact, component: Component }) => (
+                <Route
+                  key={path}
+                  path={path}
+                  exact={exact}
+                  render={() => (
+                    <ActiveTabUpdater path={path}>
+                      <Component />
+                    </ActiveTabUpdater>
+                  )}
+                />
+              ))}
             </Switch>
             <Footer />
           </Container>


### PR DESCRIPTION
# Description

This PR fixes the error in the selection on the sidebar.

This PR resolves [PADV-1104](https://agile-jira.pearson.com/browse/PADV-1104)

## Change log
- Fixed error when you reload the page or use a link to go into institution portal.
- Refactor in routes.

### How to test

Clone the Institution Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

- Pick any section [home, instructors...], reload the page the sidebar should show the section selected.
- Follow the previous step, pick the url and open it into other tab, the sidebar should show the current selection.
