### PR TITLE
PADV-1200 - Change URL related to class creation

### DIFF
--- a/src/features/Courses/data/_test_/api.test.js
+++ b/src/features/Courses/data/_test_/api.test.js
@@ -32,6 +32,6 @@ describe('should call getAuthenticatedHttpClient with the correct parameters', (
     expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();
 
     expect(httpClientMock.post).toHaveBeenCalledTimes(1);
-    expect(httpClientMock.post).toHaveBeenCalledWith('http://localhost:18000/pearson_course_operation/api/v2/create-class/', data);
+    expect(httpClientMock.post).toHaveBeenCalledWith('http://localhost:18000/pearson_course_operation/api/v2/classes/', data);
   });
 });

--- a/src/features/Courses/data/_test_/redux.test.js
+++ b/src/features/Courses/data/_test_/redux.test.js
@@ -103,7 +103,7 @@ describe('Courses redux tests', () => {
   });
 
   test('successful add class', async () => {
-    const classApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/create-class/`;
+    const classApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     const dataCreateClass = new FormData();
     const instructorData = new FormData();
     const classId = 'ccx1';
@@ -126,7 +126,7 @@ describe('Courses redux tests', () => {
   });
 
   test('failed add class', async () => {
-    const classApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/create-class/`;
+    const classApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
     const dataCreateClass = new FormData();
     const instructorData = new FormData();
 

--- a/src/features/Courses/data/api.js
+++ b/src/features/Courses/data/api.js
@@ -5,7 +5,7 @@ function handleNewClass(data) {
   const apiV2BaseUrl = getConfig().COURSE_OPERATIONS_API_V2_BASE_URL;
 
   return getAuthenticatedHttpClient().post(
-    `${apiV2BaseUrl}/create-class/`,
+    `${apiV2BaseUrl}/classes/`,
     data,
   );
 }


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1200

## Description

The URL for classes creation was changed in the Backend. So, it is necessary change it in the Frontend as well. 

## Changes Made

- [X] Change URL.
- [X] Update tests.

## How to test

- Clone the Institution Portal MFE.
- Run npm install.
- Run npm run start.
- Go to http://localhost:1980/institution-portal/courses and enter in a course and create a class.
- Verify if the class was created successfully. 