### PR TITLE
refactor: import sidebar from library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.7.8",
+        "react-paragon-topaz": "^1.7.11",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17053,9 +17053,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.7.8.tgz",
-      "integrity": "sha512-rElzs4NW8mr4mfToombdwBSIHghUpflhnmos6q/HaI8XS9OBiMSl1gD5mpnjW+H89TKQbv/hi/Z5d8a4dWyHVw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.7.11.tgz",
+      "integrity": "sha512-a3STrgbgcVbtad5oRdilUIJ4RxvpEUmcckRw7FKpaSgz+i6gLOsvnhenxjTZFLJQtTXvNreCGJAT4TDyp5gh7Q==",
       "dependencies": {
         "@edx/paragon": "^20.45.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "^1.7.8",
+    "react-paragon-topaz": "^1.7.11",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -34,3 +34,16 @@
     color: $primary;
   }
 }
+
+@media screen and (max-width: 880px) {
+  .title-page {
+    padding-left: 20px;
+  }
+}
+
+@media screen and (min-width: 600px) and (max-width: 1024px) {
+  .page-content-container {
+    max-width: 680px;
+    min-width: 680px;
+  }
+}

--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -1,13 +1,49 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+
+import { Sidebar as SidebarBase, MenuSection, MenuItem } from 'react-paragon-topaz';
+
 import { updateActiveTab } from 'features/Main/data/slice';
 import './index.scss';
 
+const menuItems = [
+  {
+    link: 'dashboard',
+    label: 'Home',
+    icon: <i className="fa-regular fa-house" />,
+  },
+  {
+    link: 'licenses',
+    label: 'License inventory',
+    icon: <i className="fa-regular fa-list-check" />,
+  },
+  {
+    link: 'instructors',
+    label: 'Instructors',
+    icon: <i className="fa-regular fa-chalkboard-user" />,
+  },
+  {
+    link: 'students',
+    label: 'Students',
+    icon: <i className="fa-regular fa-screen-users" />,
+  },
+  {
+    link: 'courses',
+    label: 'Courses',
+    icon: <i className="fa-regular fa-bars-sort" />,
+  },
+  {
+    link: 'classes',
+    label: 'Classes',
+    icon: <i className="fa-regular fa-books" />,
+  },
+];
+
 export const Sidebar = () => {
+  const history = useHistory();
   const dispatch = useDispatch();
   const activeTab = useSelector((state) => state.main.activeTab);
-  const history = useHistory();
 
   const handleTabClick = (tabName) => {
     dispatch(updateActiveTab(tabName));
@@ -15,77 +51,21 @@ export const Sidebar = () => {
   };
 
   return (
-    <header className="vertical-nav">
-      <nav className="nav-menu">
-        <ul className="nav-links">
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'dashboard' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('dashboard')}
-            >
-              <i className="fa-regular fa-house" />
-              <span className="nav-text">Home</span>
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'licenses' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('licenses')}
-            >
-              <i className="fa-regular fa-list-check" />
-              <span className="nav-text">License inventory</span>
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'instructors' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('instructors')}
-            >
-              <i className="fa-regular fa-chalkboard-user" />
-              <span className="nav-text">Instructors</span>
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'students' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('students')}
-            >
-              <i className="fa-regular fa-screen-users" />
-              <span className="nav-text">Students</span>
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'courses' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('courses')}
-            >
-              <i className="fa-regular fa-bars-sort" />
-              <span className="nav-text">Courses</span>
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              className={`${activeTab === 'classes' ? 'active' : ''} sidebar-item`}
-              aria-current="page"
-              onClick={() => handleTabClick('classes')}
-            >
-              <i className="fa-regular fa-books" />
-              <span className="nav-text">Classes</span>
-            </button>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <SidebarBase>
+      <MenuSection>
+        {
+          menuItems.map(({ link, label, icon }) => (
+            <MenuItem
+              key={link}
+              title={label}
+              path={link}
+              active={activeTab === link}
+              onClick={handleTabClick}
+              icon={icon}
+            />
+          ))
+        }
+      </MenuSection>
+    </SidebarBase>
   );
 };

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -70,8 +70,8 @@ const Main = () => {
       <CookiePolicyBanner policyText={{ en: cookieText }} />
       <Header />
       <div className="pageWrapper">
-        <Sidebar />
-        <main>
+        <main className="d-flex">
+          <Sidebar />
           <Container className="px-0 container-pages">
             <Container size="xl" className="px-4">
               {stateInstitutions.length > 1 && (
@@ -113,9 +113,9 @@ const Main = () => {
                 />
               ))}
             </Switch>
-            <Footer />
           </Container>
         </main>
+        <Footer />
       </div>
     </BrowserRouter>
   );

--- a/src/features/Main/index.scss
+++ b/src/features/Main/index.scss
@@ -24,14 +24,14 @@ input {
   overflow: visible;
 }
 
+.pageWrapper,
+.container-pages {
+  background-color: $bg-main-color;
+}
+
 .pageWrapper {
   .vertical-nav {
     z-index: 10;
-  }
-
-  nav {
-    color: $color-white;
-    width: 100%;
   }
 
   main {
@@ -41,11 +41,11 @@ input {
   }
 
   .container-pages {
-    background-color: $bg-main-color;
     background-image: url('https://pearson-production-media.s3.amazonaws.com/IPbackground.svg');
     background-repeat: no-repeat;
     background-position: top right;
     background-size: 55%;
+    padding-bottom: 40px;
   }
 }
 
@@ -96,7 +96,6 @@ li {
   .pageWrapper {
     display: grid;
     min-height: 100vh;
-    padding-left: 240px;
   }
 
   header.vertical-nav {
@@ -109,8 +108,15 @@ li {
 @media (max-width: 700px) {
   .pageWrapper {
     .container-pages {
+      padding-top: 1em;
       background-size: 90%;
     }
+  }
+}
+
+@media (max-width: 880px) {
+  .selector-institution {
+    padding-left: 20px;
   }
 }
 


### PR DESCRIPTION
# Description
In this pr is updated the sidebar, now is being using the sidebar from https://www.npmjs.com/package/react-paragon-topaz

## Screenshots
### Before
![o](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/380689f5-68db-4152-9351-52b2811f42f5)

### After
![n](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/916dc875-aa4d-436c-9092-1128411aaad6)


### How to test

Clone the Institution Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to:

- http://localhost:1980/

You should be able to navigate to all sections using the new sidebar.
