### PR TITLE
feat: dropdown option in course detail table

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -1,16 +1,22 @@
 @import "assets/colors.scss";
 @import "assets/variables.scss";
 
+.custom-text-black {
+  &:-webkit-any-link {
+    color: $color-black;
+  }
+}
+
 .page-content-container {
   .progress {
-    @extend %progress-styles;
+    @extend %progress-styles !optional;
   }
 }
 
 [role=table] {
   [role=cell] {
     .custom-progress {
-      @extend %progress-styles;
+      @extend %progress-styles !optional;
     }
   }
 }

--- a/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
+++ b/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
@@ -1,6 +1,5 @@
 import {
   fireEvent,
-  waitFor,
   screen,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
@@ -12,7 +11,7 @@ import { columns } from 'features/Courses/CourseDetailTable/columns';
 describe('columns', () => {
   test('returns an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(8);
+    expect(columns).toHaveLength(9);
 
     const [
       className,
@@ -168,7 +167,7 @@ describe('columns', () => {
     expect(component.getByText('Sam Sepiol')).toBeInTheDocument();
   });
 
-  test('Should render the assign button if instructor is not present', async () => {
+  test('Should render the label text if instructor is not present', async () => {
     const values = {
       row: {
         values: { instructors: [] },
@@ -219,14 +218,57 @@ describe('columns', () => {
       { preloadedState: mockStore },
     );
 
-    const modalButton = component.getByRole('button');
-    expect(modalButton).toBeInTheDocument();
+    const title = component.getByText('Unassigned');
+    expect(title).toBeInTheDocument();
+  });
 
-    fireEvent.click(modalButton);
+  test('Should render the dropdown menu', () => {
+    const values = {
+      row: {
+        values: { instructors: ['Sam Sepiol'] },
+        original: {
+          classId: 'Demo Course 1',
+        },
+      },
+    };
 
-    await waitFor(() => {
-      const title = component.getAllByText('Assign instructor')[0];
-      expect(title).toBeInTheDocument();
-    });
+    const Component = () => columns[8].Cell(values);
+    const mockStore = {
+      classes: {
+        table: {
+          data: [
+            {
+              masterCourseName: 'Demo MasterCourse 1',
+              className: 'Demo Class 1',
+              startDate: '09/21/24',
+              endDate: null,
+              numberOfStudents: 1,
+              maxStudents: 100,
+              instructors: ['Sam Sepiol'],
+            },
+          ],
+          count: 2,
+          num_pages: 1,
+          current_page: 1,
+        },
+      },
+    };
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/courses/Demo%20Course%201']}>
+        <Route path="/courses/:courseId">
+          <Component />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const buttonTrigger = component.getByTestId('droprown-action');
+
+    fireEvent.click(buttonTrigger);
+
+    expect(component.getByText('View class content')).toBeInTheDocument();
+    expect(component.getByText('Manage Instructors')).toBeInTheDocument();
+    expect(component.getByText('Edit Class')).toBeInTheDocument();
   });
 });

--- a/src/features/Courses/CourseDetailTable/columns.jsx
+++ b/src/features/Courses/CourseDetailTable/columns.jsx
@@ -1,16 +1,18 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import { useParams, Link } from 'react-router-dom';
+import {
+  Dropdown, useToggle, IconButton, Icon,
+} from '@edx/paragon';
+import { Badge } from 'react-paragon-topaz';
+import { MoreHoriz } from '@edx/paragon/icons';
+import { getConfig } from '@edx/frontend-platform';
 
-import { Badge, Button } from 'react-paragon-topaz';
-import AssignInstructors from 'features/Instructors/AssignInstructors';
-
-import { fetchClassesData } from 'features/Classes/data/thunks';
-import { updateClassSelected } from 'features/Instructors/data/slice';
-
-import { initialPage } from 'features/constants';
 import { formatUTCDate } from 'helpers';
+
+import AddClass from 'features/Courses/AddClass';
+
+import 'assets/global.scss';
 
 const columns = [
   {
@@ -32,22 +34,6 @@ const columns = [
     Header: 'Instructor',
     accessor: 'instructors',
     Cell: ({ row }) => {
-      const { courseId } = useParams();
-      const [isModalOpen, setIsModalOpen] = useState(false);
-
-      const dispatch = useDispatch();
-      const institution = useSelector((state) => state.main.selectedInstitution);
-
-      const handleOpenModal = () => {
-        dispatch(updateClassSelected(row.original.classId));
-        setIsModalOpen(true);
-      };
-
-      const handleCloseModal = () => {
-        dispatch(fetchClassesData(institution.id, initialPage, courseId));
-        setIsModalOpen(false);
-      };
-
       if (row.values.instructors?.length > 0) {
         return (
           <ul className="instructors-list mb-0">
@@ -57,17 +43,9 @@ const columns = [
       }
 
       return (
-        <>
-          <Button onClick={handleOpenModal} className="button-assign">
-            <i className="fa fa-plus mr-2" />
-            Assign
-          </Button>
-          <AssignInstructors
-            isOpen={isModalOpen}
-            close={handleCloseModal}
-            getClasses={false}
-          />
-        </>
+        <span className="text-danger">
+          Unassigned
+        </span>
       );
     },
   },
@@ -110,6 +88,80 @@ const columns = [
     Header: 'End date',
     accessor: 'endDate',
     Cell: ({ row }) => (row.values.endDate ? formatUTCDate(row.values.endDate, 'MM/dd/yy') : '-'),
+  },
+  {
+    Header: '',
+    accessor: 'courseName',
+    cellClassName: 'dropdownColumn',
+    disableSortBy: true,
+    Cell: ({ row }) => {
+      const {
+        masterCourseName,
+        masterCourseId,
+        classId,
+        className,
+        startDate,
+        endDate,
+        minStudentsAllowed,
+        maxStudents,
+      } = row.original;
+
+      const [isOpenModal, openModal, closeModal] = useToggle(false);
+
+      return (
+        <Dropdown className="dropdowntpz">
+          <Dropdown.Toggle
+            id="dropdown-toggle-with-iconbutton"
+            as={IconButton}
+            src={MoreHoriz}
+            iconAs={Icon}
+            variant="primary"
+            data-testid="droprown-action"
+            alt="menu for actions"
+          />
+          <Dropdown.Menu>
+            <Dropdown.Item
+              href={`${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classId}/home`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-truncate text-decoration-none custom-text-black"
+            >
+              <i className="fa-regular fa-eye mr-2 mb-1" />
+              View class content
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Link
+                to={`/manage-instructors/${masterCourseName}/${row.values.className}?classId=${classId}`}
+                className="text-truncate text-decoration-none custom-text-black"
+              >
+                <i className="fa-regular fa-chalkboard-user mr-2 mb-1" />
+                Manage Instructors
+              </Link>
+            </Dropdown.Item>
+            <Dropdown.Item onClick={openModal}>
+              <i className="fa-solid fa-pencil mr-2 mb-1" />
+              Edit Class
+            </Dropdown.Item>
+            <AddClass
+              isOpen={isOpenModal}
+              onClose={closeModal}
+              courseInfo={{
+                masterCourseName,
+                masterCourseId,
+                classId,
+                className,
+                startDate,
+                endDate,
+                minStudents: minStudentsAllowed,
+                maxStudents,
+              }}
+              isCoursePage
+              isEditing
+            />
+          </Dropdown.Menu>
+        </Dropdown>
+      );
+    },
   },
 ];
 


### PR DESCRIPTION
# Description
In this PR is added a drop-down for course detail table.

## Ticket
https://agile-jira.pearson.com/browse/PADV-1239


## Change log
- Removed add insctructor button.
- Labels in some test cases.


## Screenshots
### Before
![b](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/d8aa4c41-d534-448a-8443-255d1f835c43)



### After
![1](https://github.com/Pearson-Advance/frontend-app-institution-portal/assets/52179095/eb46c314-caa8-445e-b3d8-efd48383228b)


## How to test

Clone the Institution Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Then go to "class details" and interact with the new options.

