### PR TITLE
feat: sticky sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.7.11",
+        "react-paragon-topaz": "^1.8.0",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17053,9 +17053,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.7.11.tgz",
-      "integrity": "sha512-a3STrgbgcVbtad5oRdilUIJ4RxvpEUmcckRw7FKpaSgz+i6gLOsvnhenxjTZFLJQtTXvNreCGJAT4TDyp5gh7Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.8.0.tgz",
+      "integrity": "sha512-QfbYlIu/AXpql2+friMZJYWhsUTdCFA2aIrKR5d2kk/14hX7T7Ud32T7wlqInsI1qPJyMWQutBS30oPvKLfiCQ==",
       "dependencies": {
         "@edx/paragon": "^20.45.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "^1.7.11",
+    "react-paragon-topaz": "^1.8.0",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",


### PR DESCRIPTION
# Ticket 
https://agile-jira.pearson.com/browse/PADV-1369

## Description
In this PR is updated the library `react-paragon-topaz` to the version `1.8.0` which includes styles to add sticky effect on sidebar.

## Visual result

https://github.com/Pearson-Advance/react-paragon-topaz-library/assets/52179095/8fe91f4a-b1f8-4621-8e99-f456c79347d8


## How to test it
- Clone the repo
- Install the dependencies
- run `npm start`
- Check the result on browser ( this result is only visible if the content has scroll but you can fake it using the dev tools )