### PR TITLE
fix: class title in class schedule should be clickable

### DIFF
--- a/src/features/Dashboard/WeeklySchedule/__test__/index.test.jsx
+++ b/src/features/Dashboard/WeeklySchedule/__test__/index.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import WeeklySchedule from 'features/Dashboard/WeeklySchedule';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import { MemoryRouter } from 'react-router-dom';
+
+import WeeklySchedule from 'features/Dashboard/WeeklySchedule';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -58,7 +60,9 @@ describe('WeeklySchedule component', () => {
     },
   };
   const component = renderWithProviders(
-    <WeeklySchedule />,
+    <MemoryRouter>
+      <WeeklySchedule />
+    </MemoryRouter>,
     { preloadedState: mockStore },
   );
 

--- a/src/features/Dashboard/WeeklySchedule/index.jsx
+++ b/src/features/Dashboard/WeeklySchedule/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import { Schedule } from 'react-paragon-topaz';
 import {
@@ -76,7 +77,12 @@ const WeeklySchedule = () => {
               return (
                 <div className="class-schedule" key={classInfo?.classId}>
                   <div className="class-text">
-                    <p className="class-name">{classInfo?.className}</p>
+                    <Link
+                      className="class-name"
+                      to={`/courses/${encodeURIComponent(classInfo?.masterCourseName)}/${encodeURIComponent(classInfo?.className)}?classId=${classInfo?.classId}&previous=courses`}
+                    >
+                      {classInfo?.className}
+                    </Link>
                     <p className="class-descr">
                       <i className="fa-sharp fa-regular fa-calendar-day" />
                       {date}


### PR DESCRIPTION
# Ticket
https://agile-jira.pearson.com/browse/PADV-1441

# Description
In this PR is fixed the class title in class schedule, now is an item clickable.

## Before
![before](https://github.com/user-attachments/assets/7e6bb25a-f925-43a1-958e-df6fd4f04d5f)

## After
![after](https://github.com/user-attachments/assets/8a935b83-301f-4c15-9bbe-16b50987b1f8)


## How to test
- Make sure to have a class with the current start date
- Go to /dashboard, you should be able to see the class listed in class schedule and click in its title.
