### PR TITLE
chore: add auto_enroll field when handleEnrollment is called.

### DIFF
--- a/src/features/Classes/EnrollStudent/index.jsx
+++ b/src/features/Classes/EnrollStudent/index.jsx
@@ -43,6 +43,7 @@ const EnrollStudent = ({ isOpen, onClose, queryClassId }) => {
     formData.delete('studentEmail');
     formData.append('identifiers', studentEmail);
     formData.append('action', 'enroll');
+    formData.append('auto_enroll', 'true');
 
     try {
       setLoading(true);


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-1501

## Description

Currently we have a bug related to the enrollments allowed when they try to register as a new user into the platform. This because when we added them into a class using the institution portal (certprep-manager), the auto enroll field is not being filled right now.

## Changes made

- [x] Add auto_enroll into the FormData to enroll students

## How to test

- Start openedx services
- Enable License Enforcement https://3.basecamp.com/3966315/buckets/16531373/documents/7283593064
- Enroll pending user using the institution portal (certprep-manager) 
![Screenshot from 2024-07-23 10-56-01](https://github.com/user-attachments/assets/6192d8f7-0ffe-4709-8a5c-8015a22e7b45)
- Register the user into the platform and see that his status is changed to active
![image](https://github.com/user-attachments/assets/0481dec9-1f09-4e45-a8e7-177c2c5631bb)