### PR TITLE
fix: sidebar selection on db click

### DIFF
--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -54,6 +54,7 @@ export const Sidebar = () => {
   };
 
   const addQueryParam = useInstitutionIdQueryParam();
+  const currentSelection = activeTab.replace(/\?institutionId=\d+/, '');
 
   return (
     <SidebarBase>
@@ -64,7 +65,7 @@ export const Sidebar = () => {
               key={link}
               title={label}
               path={addQueryParam(link)}
-              active={activeTab === link}
+              active={currentSelection === link}
               onClick={handleTabClick}
               icon={icon}
             />


### PR DESCRIPTION
# Description

At the moment to make db click on any section in the sidebar, the sidebar loses the selection we still in the section selected but the sidebar does not reflect that, this PR fix it.




https://github.com/user-attachments/assets/086d945e-f2dd-4146-a3b2-ab2b2d8bec83


 