### PR TITLE
PADV-1494 (BUG) - Calculate remaining value in license details

### DIFF
--- a/src/features/Licenses/LicensesDetailPage/__test__/index.test.jsx
+++ b/src/features/Licenses/LicensesDetailPage/__test__/index.test.jsx
@@ -46,9 +46,9 @@ const mockStore = {
       data: [
         {
           licenseName: 'License Demo',
-          purchasedSeats: 10,
-          numberOfStudents: 20,
-          numberOfPendingStudents: 10,
+          purchasedSeats: 20,
+          numberOfStudents: 10,
+          numberOfPendingStudents: 5,
         },
       ],
       count: 1,

--- a/src/features/Licenses/LicensesDetailPage/index.jsx
+++ b/src/features/Licenses/LicensesDetailPage/index.jsx
@@ -110,8 +110,8 @@ const LicensesDetailPage = () => {
               <div className="separator mx-4" />
               <div className="d-flex flex-column align-items-center">
                 <p className="title">Remaining</p>
-                <span className="value number-of-pending">
-                  {licenseInfo.numberOfPendingStudents}
+                <span className="value number-of-remaining">
+                  {licenseInfo.purchasedSeats - licenseInfo.numberOfStudents - licenseInfo.numberOfPendingStudents}
                 </span>
               </div>
             </>

--- a/src/features/Licenses/LicensesDetailPage/index.scss
+++ b/src/features/Licenses/LicensesDetailPage/index.scss
@@ -46,7 +46,7 @@
     font-weight: bold;
   }
 
-  .number-of-pending {
+  .number-of-remaining {
     color: red;
   }
 


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1494

### Description

In order to be consistence with values for licenses, we decided to calculate remaining value correctly.

### Changes made

- [x] Remaining value is calculated in license details.

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to http://localhost:1980/institution-portal/
- Go to license view and verify if remaining value is the same in license details