### PR TITLE
PADV-1613 - Classes endpoint is called correctly after class creation

### DIFF
--- a/src/features/Courses/AddClass/index.jsx
+++ b/src/features/Courses/AddClass/index.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import {
@@ -23,7 +22,6 @@ import 'features/Courses/AddClass/index.scss';
 const AddClass = ({
   isOpen, onClose, courseInfo, isCoursePage, isEditing, isDetailClassPage,
 }) => {
-  const { courseName } = useParams();
   const dispatch = useDispatch();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const instructorsList = useSelector((state) => state.instructors.selectOptions.data);
@@ -36,8 +34,6 @@ const AddClass = ({
   const [maxStudents, setMaxStudents] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-
-  const courseNameDecoded = courseName ? decodeURIComponent(courseName) : '';
 
   const handleAddClass = async (e) => {
     e.preventDefault();
@@ -61,9 +57,9 @@ const AddClass = ({
         logError(error);
       } finally {
         if (isDetailClassPage) {
-          dispatch(fetchAllClassesData(selectedInstitution.id, courseNameDecoded));
+          dispatch(fetchAllClassesData(selectedInstitution.id, courseInfo.masterCourseId));
         } else {
-          dispatch(fetchClassesData(selectedInstitution.id, initialPage, courseNameDecoded));
+          dispatch(fetchClassesData(selectedInstitution.id, initialPage, courseInfo.masterCourseId));
           dispatch(updateClassesCurrentPage(initialPage));
         }
       }
@@ -87,7 +83,7 @@ const AddClass = ({
           dispatch(fetchCoursesData(selectedInstitution.id, initialPage));
           dispatch(updateCoursesCurrentPage(initialPage));
         } else {
-          dispatch(fetchClassesData(selectedInstitution.id, initialPage, courseNameDecoded));
+          dispatch(fetchClassesData(selectedInstitution.id, initialPage, courseInfo.masterCourseId));
           dispatch(updateClassesCurrentPage(initialPage));
         }
       }


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1613

### Description

Classes endpoint was being called without course_id value set.

### Changes made

- [x] "Add class" component was modified.

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to http://localhost:1980/institution-portal/courses
- Choose any course and create a class
- Check if classes were filtered after class creation correctly