### PR TITLE
PADV-1645 - Add spinner loader before display unauthorized page

### DIFF
--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -9,7 +9,7 @@ import {
 } from 'react-router-dom';
 
 import { getConfig } from '@edx/frontend-platform';
-import { Container } from '@edx/paragon';
+import { Container, Spinner } from '@edx/paragon';
 
 import CookiePolicyBanner from '@pearsonedunext/frontend-component-cookie-policy-banner';
 
@@ -36,7 +36,7 @@ import { updateSelectedInstitution } from 'features/Main/data/slice';
 
 import { useInstitutionIdQueryParam } from 'hooks';
 
-import { cookieText, INSTITUTION_QUERY_ID } from 'features/constants';
+import { cookieText, INSTITUTION_QUERY_ID, RequestStatus } from 'features/constants';
 
 import './index.scss';
 
@@ -48,6 +48,9 @@ const Main = () => {
   const addQueryParam = useInstitutionIdQueryParam();
 
   const searchParams = new URLSearchParams(location.search);
+
+  const statusInstitutions = useSelector((state) => state.main.institution.status);
+  const isLoadingInstitutions = statusInstitutions === RequestStatus.LOADING;
 
   useEffect(() => {
     dispatch(fetchInstitutionData());
@@ -82,8 +85,17 @@ const Main = () => {
       <Header />
       <div className="pageWrapper">
         <main className="d-flex">
-          {institutions.length < 1 && <UnauthorizedPage />}
-          {institutions.length > 0 && (
+          {isLoadingInstitutions && (
+            <div className="w-100 h-100 d-flex justify-content-center align-items-center">
+              <Spinner
+                animation="border"
+                className="mie-3"
+                screenReaderText="loading"
+              />
+            </div>
+          )}
+          {!isLoadingInstitutions && institutions.length < 1 && <UnauthorizedPage />}
+          {!isLoadingInstitutions && institutions.length > 0 && (
             <>
               <Sidebar />
               <Container className="px-0 container-pages">


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1645

### Description

Unauthorized page is being displayed briefly. So, in order to avoid that behavior, this PR adds a spinner loader instead.

### Changes made

- [x] Add spinner loader in Main component.

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to http://localhost:1980/certprep-manager
- Refresh portal more than one time and check if unauthorized page is displayed or not (it should not).
- Retry with a no global staff user.