### PR TITLE
PADV-1705 - Change course_name by course_id in class filters

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -18,6 +18,7 @@ jest.mock('react-router-dom', () => ({
 let axiosMock;
 
 const courseOption = {
+  masterCourseId: 1,
   masterCourseName: 'Demo Course 1',
   numberOfClasses: 1,
   missingClassesForInstructor: null,

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -82,7 +82,7 @@ const ClassesFilters = ({ resetPagination }) => {
       ? courses.map(course => ({
         ...course,
         label: course.masterCourseName,
-        value: course.masterCourseName,
+        value: course.masterCourseId,
       })) : [];
 
     const parseInstructorsToOptions = instructors?.length > 0


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1705

### Description

Classes filtering was failing because frontend was considering course_name instead of course_id.  

### Changes made

- [x] Modify filter in Classes view.
- [x] Modify tests related to filters 

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to http://localhost:1980/certprep-manager/classes
- Filter by course and check if the result is correct.