### PR TITLE
PADV-1496 - Update version of react-paragon-topaz to 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.15.0",
+        "react-paragon-topaz": "^1.16.0",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17174,9 +17174,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.15.0.tgz",
-      "integrity": "sha512-uT7BNO2ZFkCFYLXNuDIRrS5ETBRb8bXZfrqYPJPQr+baJd8LT/5or4pQVUt77cetyaS3W1TpI3A+PFWYdn+lgQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.16.0.tgz",
+      "integrity": "sha512-gdeFNPqXLcsCqmpiCAgyZ1ZXQyt4dRjCtK0DESN6zBYfW69PzWJjxpfk+GQHgh0MEZwHnW4qdc1cZ7Y2zFjM+A==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "^1.15.0",
+    "react-paragon-topaz": "^1.16.0",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1496

### Description

This PR was opened in order to display dropdown menu correctly.

### Changes made

- [x] Update react-paragon-topaz version

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to /Courses/Classes and check if dropdown menu is displayed correctly.