### PR TITLE
PADV-1885 - Fix license inventory pagination

### DIFF
--- a/src/features/Licenses/LicensesDetailPage/index.jsx
+++ b/src/features/Licenses/LicensesDetailPage/index.jsx
@@ -48,14 +48,14 @@ const LicensesDetailPage = () => {
 
   useEffect(() => {
     if (institution.id) {
-      dispatch(fetchCoursesData(institution.id, initialPage, { license_id: licenseId }));
+      dispatch(fetchCoursesData(institution.id, currentPage, { license_id: licenseId }));
       dispatch(fetchLicensesData(institution.id, initialPage, licenseId));
     }
 
     return () => {
       dispatch(resetCoursesTable());
     };
-  }, [dispatch, institution.id, licenseId]);
+  }, [dispatch, institution.id, licenseId, currentPage]);
 
   useEffect(() => {
     if (institution.id !== undefined && institutionRef.current === undefined) {


### PR DESCRIPTION
### Ticket

https://agile-jira.pearson.com/browse/PADV-1885

### Description

This PR solves an error related to pagination in License Inventory.

### Changes made

- [x] Add currentPage in useEffect hook.

### How to test

- Clone the Institution Portal MFE
- Run npm install
- Run npm run start
- Go to /licenses and select a license with more than one course.
- Check pagination is working.