### PR TITLE
feat: display search on course filter

### DIFF
--- a/src/features/Courses/CoursesFilters/index.jsx
+++ b/src/features/Courses/CoursesFilters/index.jsx
@@ -16,10 +16,11 @@ const CoursesFilters = () => {
   const [courseOptions, setCourseOptions] = useState([]);
   const [courseSelected, setCourseSelected] = useState(null);
   const [inputCourse, setInputCourse] = useState('');
+  const [defaultOption, setDefaultOption] = useState(allResultsOption);
 
   const filterOptions = (option, input) => {
     if (input) {
-      return option.label.toLowerCase().includes(input) || option.value === allResultsOption.value;
+      return option.label.toLowerCase().includes(input) || option.value === defaultOption.value;
     }
     return true;
   };
@@ -27,6 +28,10 @@ const CoursesFilters = () => {
   const handleInputChange = (value, { action }) => {
     if (action === 'input-change') {
       setInputCourse(value);
+      setDefaultOption({
+        ...defaultOption,
+        label: `${allResultsOption.label} for ${value}`,
+      });
     }
   };
 
@@ -46,19 +51,20 @@ const CoursesFilters = () => {
       }))
       : [];
 
-    setCourseOptions([allResultsOption, ...options]);
-  }, [courses]);
+    setCourseOptions([defaultOption, ...options]);
+  }, [courses, defaultOption]);
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
       const params = {};
 
       if (courseSelected) {
-        params.course_name = courseSelected.value === allResultsOption.value
+        params.course_name = courseSelected.value === defaultOption.value
           ? inputCourse : courseSelected.value;
       }
       dispatch(fetchCoursesData(selectedInstitution.id, initialPage, params));
       setInputCourse('');
+      setDefaultOption(allResultsOption);
       dispatch(updateFilters(params));
       dispatch(updateCurrentPage(initialPage));
     }


### PR DESCRIPTION
# Description

This PR resolves [PADV-1882](https://agile-jira.pearson.com/browse/PADV-1882) now the filter shows the search made

## Change log
- Updated `CourseFilters` to show the search maded.

### Visual results
#### Before
![certprepcourseware-staging pearson com_certprep-manager_courses_institutionId=3](https://github.com/user-attachments/assets/0170f17e-1bd4-462d-a787-28d8d8965e61)



#### After
![localhost_1980_institution-portal_courses_institutionId=1](https://github.com/user-attachments/assets/5b4fdaee-f275-4eec-8f07-4ea992f01582)


### How to test

Clone the Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to courses/ and test the results.
