### PR TITLE
feat: switch button to get only my courses

### DIFF
--- a/src/features/Courses/CoursesFilters/index.jsx
+++ b/src/features/Courses/CoursesFilters/index.jsx
@@ -4,15 +4,19 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Col, Form } from '@edx/paragon';
 import { Select } from 'react-paragon-topaz';
 
-import { updateFilters, updateCurrentPage } from 'features/Courses/data/slice';
+import { updateFilters, updateCurrentPage, updateShowAllCourses } from 'features/Courses/data/slice';
 import { fetchCoursesData, fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 
-import { initialPage, styleFirstOption, allResultsOption } from 'features/constants';
+import {
+  initialPage, styleFirstOption, allResultsOption, RequestStatus,
+} from 'features/constants';
 
 const CoursesFilters = () => {
   const dispatch = useDispatch();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const courses = useSelector((state) => state.courses.selectOptions);
+  const showAllCourses = useSelector((state) => state.courses.showAllCourses);
+  const coursesRequest = useSelector((state) => state.courses.table.status);
   const [courseOptions, setCourseOptions] = useState([]);
   const [courseSelected, setCourseSelected] = useState(null);
   const [inputCourse, setInputCourse] = useState('');
@@ -35,6 +39,8 @@ const CoursesFilters = () => {
     }
   };
 
+  const handleToggleChange = e => dispatch(updateShowAllCourses(e.target.checked));
+
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
       setCourseSelected(null);
@@ -56,7 +62,9 @@ const CoursesFilters = () => {
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
-      const params = {};
+      const params = {
+        has_classes: showAllCourses,
+      };
 
       if (courseSelected) {
         params.course_name = courseSelected.value === defaultOption.value
@@ -68,8 +76,11 @@ const CoursesFilters = () => {
       dispatch(updateFilters(params));
       dispatch(updateCurrentPage(initialPage));
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [courseSelected, selectedInstitution]);
+  }, [courseSelected, selectedInstitution, showAllCourses]);
+
+  const isLoading = coursesRequest === RequestStatus.LOADING;
 
   return (
     <div className="filter-container justify-content-center row">
@@ -94,6 +105,16 @@ const CoursesFilters = () => {
                 styles={styleFirstOption}
               />
             </Form.Group>
+          </Form.Row>
+          <Form.Row className="w-100 mt-2">
+            <Form.Switch
+              checked={showAllCourses}
+              onChange={handleToggleChange}
+              className="ml-3"
+              disabled={isLoading}
+            >
+              Show my courses
+            </Form.Switch>
           </Form.Row>
         </Form>
       </div>

--- a/src/features/Courses/data/slice.js
+++ b/src/features/Courses/data/slice.js
@@ -19,6 +19,7 @@ const initialState = {
     data: null,
   },
   notificationMessage: '',
+  showAllCourses: false,
 };
 
 export const coursesSlice = createSlice({
@@ -67,6 +68,9 @@ export const coursesSlice = createSlice({
     updateNotificationMsg: (state, { payload }) => {
       state.notificationMessage = payload;
     },
+    updateShowAllCourses: (state, { payload }) => {
+      state.showAllCourses = payload;
+    },
   },
 });
 
@@ -83,6 +87,7 @@ export const {
   newClassFailed,
   resetClassState,
   updateNotificationMsg,
+  updateShowAllCourses,
 } = coursesSlice.actions;
 
 export const { reducer } = coursesSlice;


### PR DESCRIPTION
# Description

This PR adds a toggle button to filter the courses.

This PR resolves [PADV-1793](https://agile-jira.pearson.com/browse/PADV-1793)

> [!WARNING]  
> You must have the changes of the PR https://github.com/Pearson-Advance/course_operations/pull/286 if the PR still unmerged in main branch do a checkout to test this locally 


## Change log
- Added button to filter courses

### Visual results
#### Before
![image](https://github.com/user-attachments/assets/3dff82bc-4673-45f9-9a5c-d4df72e19732)

#### After
![image](https://github.com/user-attachments/assets/a2f4e50d-46d8-45a1-8559-dec3a57158b6)

### How to test

Clone the Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to /courses and test the results.






