### PR TITLE
feat: instructor profile info

### DIFF
--- a/src/features/Instructors/InstructorsDetailPage/__test__/index.test.jsx
+++ b/src/features/Instructors/InstructorsDetailPage/__test__/index.test.jsx
@@ -88,10 +88,43 @@ const mockStore = {
       num_pages: 1,
       current_page: 1,
     },
+    instructorProfile: {
+      instructorId: 20,
+      instructorImage: '',
+      instructorUsername: 'instructor',
+      instructorName: 'Instructor 3 ',
+      instructorEmail: 'instructor2@example.com',
+      lastAccess: '2024-02-26T15:53:03Z',
+      created: '2024-02-26T15:53:02Z',
+      classes: 2,
+      status: 'success',
+    },
   },
 };
 
 describe('InstructorsDetailPage', () => {
+  test('Should render instructor profile', async () => {
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/instructors/instructor']}>
+        <Route path="/instructors/:instructorUsername">
+          <InstructorsDetailPage />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    waitFor(() => {
+      expect(component.container).toHaveTextContent('Profile');
+      expect(component.container).toHaveTextContent('Instructor 3');
+      expect(component.container).toHaveTextContent('instructor2@example.com');
+      expect(component.container).toHaveTextContent('Courses taught');
+      expect(component.container).toHaveTextContent('Instructor since');
+      expect(component.container).toHaveTextContent('02/26/24');
+      expect(component.container).toHaveTextContent('Last online');
+      expect(component.container).toHaveTextContent('02/26/24');
+    });
+  });
+
   test('renders classes data and pagination', async () => {
     const component = renderWithProviders(
       <MemoryRouter initialEntries={['/instructors/instructor']}>

--- a/src/features/Instructors/data/__test__/api.test.js
+++ b/src/features/Instructors/data/__test__/api.test.js
@@ -3,6 +3,7 @@ import {
   handleInstructorsEnrollment,
   handleNewInstructor,
   getEventsByInstructor,
+  getInstructorByEmail,
 } from 'features/Instructors/data/api';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
@@ -96,6 +97,30 @@ describe('should call getAuthenticatedHttpClient with the correct parameters', (
           start_date: '2024-12-01T05:00:00.000Z',
           end_date: '2025-01-01T04:59:59.999Z',
           page: '1',
+        },
+      },
+    );
+  });
+
+  test('getInstructorByEmail', () => {
+    const httpClientMock = {
+      get: jest.fn(),
+    };
+
+    getAuthenticatedHttpClient.mockReturnValue(httpClientMock);
+
+    getInstructorByEmail('edx@example.com');
+
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledTimes(1);
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();
+
+    expect(httpClientMock.get).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.get).toHaveBeenCalledWith(
+      'http://localhost:18000/pearson_course_operation/api/v2/instructors/',
+      {
+        params: {
+          instructor_email: 'edx@example.com',
+          limit: false,
         },
       },
     );

--- a/src/features/Instructors/data/api.js
+++ b/src/features/Instructors/data/api.js
@@ -31,8 +31,35 @@ function getEventsByInstructor(params) {
   );
 }
 
+/**
+ * Retrieves instructor information based on their email address.
+ *
+ * @param email - Takes an `email` parameter which is used to
+ *                search for an instructor by their email address.
+ * @param [options] - Is an object that can contain additional configuration settings.
+ *
+ * @returns {Promise} the result of a GET request made to the specified URL
+ */
+function getInstructorByEmail(email, options = {}) {
+  const defaultParams = {
+    limit: false,
+  };
+
+  const params = {
+    instructor_email: email,
+    ...defaultParams,
+    ...options,
+  };
+
+  return getAuthenticatedHttpClient().get(
+    `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/instructors/`,
+    { params },
+  );
+}
+
 export {
   handleInstructorsEnrollment,
   handleNewInstructor,
   getEventsByInstructor,
+  getInstructorByEmail,
 };

--- a/src/features/Instructors/data/index.js
+++ b/src/features/Instructors/data/index.js
@@ -1,7 +1,8 @@
-export { reducer, resetEvents } from 'features/Instructors/data/slice';
+export { reducer, resetEvents, resetInstructorInfo } from 'features/Instructors/data/slice';
 export {
   fetchInstructorsData,
   assignInstructors,
   fetchInstructorsOptionsData,
   fetchEventsData,
+  fetchInstructorProfile,
 } from 'features/Instructors/data/thunks';

--- a/src/features/Instructors/data/slice.js
+++ b/src/features/Instructors/data/slice.js
@@ -39,6 +39,13 @@ const initialState = {
       end_date: endOfMonth(new Date()).toISOString(),
     },
   },
+  instructorProfile: {
+    status: RequestStatus.LOADING,
+    instructorImage: '',
+    instructorName: '',
+    lastAccess: '',
+    created: '',
+  },
 };
 
 export const instructorsSlice = createSlice({
@@ -119,6 +126,15 @@ export const instructorsSlice = createSlice({
     updateEventsRequestStatus: (state, { payload }) => {
       state.events.status = payload;
     },
+    updateInstructorInfo: (state, { payload }) => {
+      state.instructorProfile = payload;
+    },
+    resetInstructorInfo: (state) => {
+      state.instructorProfile = initialState.instructorProfile;
+    },
+    updateInstructorInfoStatus: (state, { payload }) => {
+      state.instructorProfile.status = payload;
+    },
   },
 });
 
@@ -144,6 +160,9 @@ export const {
   fetchInstructorOptionsSuccess,
   fetchInstructorOptionsFailed,
   resetInstructorOptions,
+  updateInstructorInfo,
+  resetInstructorInfo,
+  updateInstructorInfoStatus,
 } = instructorsSlice.actions;
 
 export const { reducer } = instructorsSlice;

--- a/src/features/Instructors/data/thunks.js
+++ b/src/features/Instructors/data/thunks.js
@@ -1,7 +1,12 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
-import { handleInstructorsEnrollment, handleNewInstructor, getEventsByInstructor } from 'features/Instructors/data/api';
 import { getInstructorByInstitution } from 'features/Common/data/api';
+import {
+  handleInstructorsEnrollment,
+  handleNewInstructor,
+  getEventsByInstructor,
+  getInstructorByEmail,
+} from 'features/Instructors/data/api';
 import {
   updateEvents,
   fetchInstructorsDataRequest,
@@ -9,6 +14,8 @@ import {
   fetchInstructorsDataFailed,
   assignInstructorsRequest,
   assignInstructorsSuccess,
+  updateInstructorInfoStatus,
+  updateInstructorInfo,
   assignInstructorsFailed,
   updateEventsRequestStatus,
   updateInstructorAdditionRequest,
@@ -140,10 +147,38 @@ function fetchEventsData(eventData, currentEvents = []) {
   };
 }
 
+/**
+ * The function fetches an instructor's profile information based on their email address and updates
+ * the store accordingly.
+ *
+ * @param email - The `email` parameter in the `fetchInstructorProfile` function is the email address
+ * of the instructor whose profile you want to fetch.
+ * @param [options] - The `options` parameter is an object that can contain additional configuration settings.
+ */
+function fetchInstructorProfile(email, options = {}) {
+  return async (dispatch) => {
+    dispatch(updateInstructorInfoStatus(RequestStatus.LOADING));
+
+    try {
+      const response = camelCaseObject(await getInstructorByEmail(email, options));
+      const instructorInfo = {
+        ...response?.data[0] || {},
+      };
+
+      dispatch(updateInstructorInfo(instructorInfo));
+      dispatch(updateInstructorInfoStatus(RequestStatus.SUCCESS));
+    } catch (error) {
+      logError(error);
+      dispatch(updateInstructorInfoStatus(RequestStatus.ERROR));
+    }
+  };
+}
+
 export {
   fetchInstructorsData,
   assignInstructors,
   addInstructor,
   fetchEventsData,
   fetchInstructorsOptionsData,
+  fetchInstructorProfile,
 };


### PR DESCRIPTION
# Description

Is added `Profile` tab in instructor detail page.

This PR resolves [PADV-1637](https://agile-jira.pearson.com/browse/PADV-1637)

## Change log
- Added `ProfileCard` from `react-paragon-topaz`
- Added instructor info in `InstructorDetailPage`
- Updated unit test

### Visual results
#### Before
![b](https://github.com/user-attachments/assets/5c6d4794-9d97-42ba-b9c0-6cabcf84b500)


#### After
![2025-01-13_16-51](https://github.com/user-attachments/assets/04742583-6e97-4302-833a-57996b22a4c1)


### How to test
- Go to /instructors and select one
You should be able to see the instructor profile tab

