### PR TITLE
fix: course filters toggle

### DIFF
--- a/src/features/Courses/CoursesFilters/index.jsx
+++ b/src/features/Courses/CoursesFilters/index.jsx
@@ -5,21 +5,24 @@ import { Col, Form } from '@edx/paragon';
 import { Select } from 'react-paragon-topaz';
 import { getConfig } from '@edx/frontend-platform';
 
-import { updateFilters, updateCurrentPage, updateShowAllCourses } from 'features/Courses/data/slice';
+import { updateFilters, updateCurrentPage } from 'features/Courses/data/slice';
 import { fetchCoursesData, fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 
 import {
-  initialPage, styleFirstOption, allResultsOption, RequestStatus,
+  initialPage,
+  styleFirstOption,
+  allResultsOption,
+  RequestStatus,
 } from 'features/constants';
 
 const CoursesFilters = () => {
   const dispatch = useDispatch();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const courses = useSelector((state) => state.courses.selectOptions);
-  const showAllCourses = useSelector((state) => state.courses.showAllCourses);
   const coursesRequest = useSelector((state) => state.courses.table.status);
   const [courseOptions, setCourseOptions] = useState([]);
   const [courseSelected, setCourseSelected] = useState(null);
+  const [filterMyCourses, setFilterMyCourses] = useState(false);
   const [inputCourse, setInputCourse] = useState('');
   const [defaultOption, setDefaultOption] = useState(allResultsOption);
 
@@ -40,9 +43,19 @@ const CoursesFilters = () => {
         label: `${allResultsOption.label} for ${value}`,
       });
     }
+
+    if (action === 'set-value' && filterMyCourses) {
+      setFilterMyCourses(false);
+    }
   };
 
-  const handleToggleChange = e => dispatch(updateShowAllCourses(e.target.checked));
+  const handleToggleChange = e => {
+    if (e.target.checked) {
+      setCourseSelected(null);
+    }
+
+    setFilterMyCourses(e.target.checked);
+  };
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
@@ -65,14 +78,13 @@ const CoursesFilters = () => {
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
-      const params = {
-        has_classes: showAllCourses,
-      };
+      const params = { has_classes: filterMyCourses };
 
       if (courseSelected) {
         params.course_name = courseSelected.value === defaultOption.value
           ? inputCourse : courseSelected.value;
       }
+
       dispatch(fetchCoursesData(selectedInstitution.id, initialPage, params));
       setInputCourse('');
       setDefaultOption(allResultsOption);
@@ -81,7 +93,7 @@ const CoursesFilters = () => {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [courseSelected, selectedInstitution, showAllCourses]);
+  }, [courseSelected, selectedInstitution, filterMyCourses]);
 
   const isLoading = coursesRequest === RequestStatus.LOADING;
 
@@ -113,7 +125,7 @@ const CoursesFilters = () => {
             showCoursesToggle && (
               <Form.Row className="w-100 mt-2">
                 <Form.Switch
-                  checked={showAllCourses}
+                  checked={filterMyCourses}
                   onChange={handleToggleChange}
                   className="ml-3"
                   disabled={isLoading}

--- a/src/features/Courses/data/slice.js
+++ b/src/features/Courses/data/slice.js
@@ -19,7 +19,6 @@ const initialState = {
     data: null,
   },
   notificationMessage: '',
-  showAllCourses: false,
 };
 
 export const coursesSlice = createSlice({
@@ -68,9 +67,6 @@ export const coursesSlice = createSlice({
     updateNotificationMsg: (state, { payload }) => {
       state.notificationMessage = payload;
     },
-    updateShowAllCourses: (state, { payload }) => {
-      state.showAllCourses = payload;
-    },
   },
 });
 
@@ -87,7 +83,6 @@ export const {
   newClassFailed,
   resetClassState,
   updateNotificationMsg,
-  updateShowAllCourses,
 } = coursesSlice.actions;
 
 export const { reducer } = coursesSlice;


### PR DESCRIPTION
# Description

This PR updates the functionality of the toggle used to filter courses. Previously, when you visited _http://localhost:1980/institution-portal/courses_ and entered a search term to find a course, toggling the "Show my courses" option would leave the search term intact in the filter. This PR fixes that issue by clearing the input so that only your courses are displayed. Additionally, if you enable the toggle to show your courses and then perform a new search, the toggle automatically resets to its default state.

_This PR resolves [PADV-2058](https://agile-jira.pearson.com/browse/PADV-2058)_

## Change log
- Renamed test folder, now uses double _
- Improved unit test.
- Removed state for redux, now is handled locally by the component.
- Renamed boolean variables for something more meaningful.

### How to test

Open the Courses Page:
   Navigate to _http://localhost:1980/institution-portal/courses_ in your browser.

Perform an Initial Search:
   - Enter a search term in the input field (e.g., "mathematics" or "history").  
   - Verify that courses matching the search term are displayed.

Test the "Show My Courses" Toggle with an Active Search:
   - With the search term still present, activate the "Show my courses" toggle.  
   - Confirm that the search input is automatically cleared.  
   - Verify that only your courses are displayed, without the previous search filter being applied.

Test the Toggle Reset on a New Search:
   - Activate the "Show my courses" toggle if needed.  
   - Enter a new search term.  
   - Verify that the toggle automatically resets to its default state once the new search is executed.
