### PR TITLE
fix: change email input type to text in student filters

### DIFF
--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -128,7 +128,7 @@ const StudentsFilters = ({ resetPagination }) => {
               {inputFieldDisplay === 'email' && (
                 <Form.Group as={Col}>
                   <Form.Control
-                    type="email"
+                    type="text"
                     floatingLabel="Student Email"
                     name="learner_email"
                     placeholder="Enter Student Email"


### PR DESCRIPTION

# Description  

This PR updates the input type in **StudentsFilter**, changing it from `email` to `text` to enable **partial email searches**. Previously, searches required a full email match, but with this change, users can find students by entering only a part of their email.  

This improves usability when filtering students based on incomplete email information.  

This PR resolves [PADV-1907](https://agile-jira.pearson.com/browse/PADV-1907)  

## Change log  
- Changed input type from `email` to `text` in **StudentsFilter**  
- Enabled partial email searches  

### Visual results  
_No visual changes_

### How to test  
1. Go to the **StudentsFilter** form.  
2. Enter a partial email in the search field.  
3. The table should display students matching the partial email input.  
4. You should be able to find a student without entering their full email address.  
