### PR TITLE
fix: change email input type to text in instructors filters

### DIFF
--- a/src/features/Instructors/InstructorsFilters/index.jsx
+++ b/src/features/Instructors/InstructorsFilters/index.jsx
@@ -115,7 +115,7 @@ const InstructorsFilters = ({ resetPagination, isAssignSection }) => {
                   {inputFieldDisplay === 'email' && (
                     <Form.Group as={Col}>
                       <Form.Control
-                        type="email"
+                        type="text"
                         floatingLabel="Instructor Email"
                         name="instructor_email"
                         placeholder="Enter Instructor Email"


### PR DESCRIPTION
# Description  

This PR updates the input type in **InstructorsFilters**, changing it from `email` to `text` to enable **partial email searches**. Previously, searches required a full email match, but with this change, users can find instructors by entering only a part of their email.  

This improves usability when filtering instructors based on incomplete email information.  

This PR is part of [PADV-1907](https://agile-jira.pearson.com/browse/PADV-1907)  

## Change log  
- Changed input type from `email` to `text` in **InstructorsFilters**  
- Enabled partial email searches  

### Visual results  
_No visual changes_

### How to test  
1. Go to the **InstructorsFilters** form.  
2. Enter a partial email in the search field.  
3. The table should display instructors matching the partial email input.  
4. You should be able to find a instructor without entering their full email address.  
