### PR TITLE
fix: username when value is 'nofullname'

### DIFF
--- a/src/features/Main/Header/index.jsx
+++ b/src/features/Main/Header/index.jsx
@@ -6,7 +6,9 @@ import { Header as HeaderBase } from 'react-paragon-topaz';
 
 export const Header = () => {
   const { authenticatedUser } = useContext(AppContext);
-  const userName = authenticatedUser.name || authenticatedUser.username;
+  const userName = !authenticatedUser.name || authenticatedUser.name === 'nofullname'
+    ? authenticatedUser.username
+    : authenticatedUser.name;
   const questionsLink = () => `${getConfig().HEADER_QUESTIONS_LINK}`;
   const platformName = getConfig().PLATFORM_NAME ? getConfig().PLATFORM_NAME : 'Pearson Skilling Administrator';
 


### PR DESCRIPTION
# Description  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Fixed an issue where the header displayed `nofullname` when the authenticated user's `name` existed but contained that value.  

### How to test  
1. Use a test user whose `user.profile.name` field is set. The header should display that name.  
2. Use another test user with no value set for `user.profile.name` or with `"nofullname"`. The header should now display the `username` instead.  
3. Verify that removing the `user.profile.name` value also results in the `username` being displayed.  
