### PR TITLE
PADV-2203 chore: point lab dashboard button to skillable and xtreme labs api

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -104,7 +104,7 @@ describe('columns', () => {
     expect(getByText('Delete Class')).toBeInTheDocument();
   });
 
-  test('Show Lab summary option when link is sent', async () => {
+  test('Show Lab Dashboard option when link is sent', async () => {
     const ActionColumn = () => columns[8].Cell({
       row: {
         values: {
@@ -112,7 +112,7 @@ describe('columns', () => {
         },
         original: {
           ...classDataMock,
-          labSummaryUrl: 'https: //',
+          labSummaryTag: 'skillable-dashboard',
         },
       },
     });
@@ -121,7 +121,7 @@ describe('columns', () => {
       classes: {
         table: {
           data: [
-            { ...classDataMock, labSummaryUrl: 'https: //' },
+            { ...classDataMock, labSummaryTag: 'skillable-dashboard' },
           ],
           count: 2,
           num_pages: 1,
@@ -143,6 +143,6 @@ describe('columns', () => {
 
     const button = getByTestId('droprown-action');
     fireEvent.click(button);
-    expect(getByText('Lab summary')).toBeInTheDocument();
+    expect(getByText('Lab Dashboard')).toBeInTheDocument();
   });
 });

--- a/src/features/Classes/data/_test_/api.test.js
+++ b/src/features/Classes/data/_test_/api.test.js
@@ -1,0 +1,50 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+import { handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
+
+describe('API functions', () => {
+  const mockPost = jest.fn();
+  const mockConfig = {
+    LMS_BASE_URL: 'https://example.com',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
+    getConfig.mockReturnValue(mockConfig);
+  });
+
+  describe('handleSkillableDashboard', () => {
+    it('should call the correct API endpoint with the correct payload', async () => {
+      const courseId = '12345';
+      const expectedUrl = `${mockConfig.LMS_BASE_URL}/skillable_plugin/course-tab/api/v1/instructor-dashboard-launch/`;
+      const expectedPayload = { class_id: courseId };
+
+      await handleSkillableDashboard(courseId);
+
+      expect(getAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockPost).toHaveBeenCalledWith(expectedUrl, expectedPayload);
+    });
+  });
+
+  describe('handleXtremeLabsDashboard', () => {
+    it('should call the correct API endpoint with the correct payload', async () => {
+      const courseId = '67890';
+      const expectedUrl = `${mockConfig.LMS_BASE_URL}/xtreme_labs_plugin/course-tab/api/v1/instructor-dashboard-launch/`;
+      const expectedPayload = { class_id: courseId };
+
+      await handleXtremeLabsDashboard(courseId);
+
+      expect(getAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockPost).toHaveBeenCalledWith(expectedUrl, expectedPayload);
+    });
+  });
+});

--- a/src/features/Classes/data/api.js
+++ b/src/features/Classes/data/api.js
@@ -1,0 +1,25 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+
+function handleSkillableDashboard(courseId) {
+  const SKILLABLE_API_URL = `${getConfig().LMS_BASE_URL}/skillable_plugin/course-tab/api/v1`;
+
+  return getAuthenticatedHttpClient().post(
+    `${SKILLABLE_API_URL}/instructor-dashboard-launch/`,
+    { class_id: courseId },
+  );
+}
+
+function handleXtremeLabsDashboard(courseId) {
+  const XTREME_LABS_API_URL = `${getConfig().LMS_BASE_URL}/xtreme_labs_plugin/course-tab/api/v1`;
+
+  return getAuthenticatedHttpClient().post(
+    `${XTREME_LABS_API_URL}/instructor-dashboard-launch/`,
+    { class_id: courseId },
+  );
+}
+
+export {
+  handleSkillableDashboard,
+  handleXtremeLabsDashboard,
+};

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -12,6 +12,7 @@ import {
   fetchAllClassesDataFailed,
 } from 'features/Classes/data/slice';
 
+import { handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
 import { getClassesByInstitution } from 'features/Common/data/api';
 import { initialPage } from 'features/constants';
 
@@ -71,8 +72,40 @@ function fetchAllClassesData(id, courseId = '', urlParamsFilters = '', limit = f
   };
 }
 
+function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
+  return async () => {
+    try {
+      const labDashboardOptions = {
+        'skillable-dashboard': handleSkillableDashboard,
+        'xtreme-labs-dashboard': handleXtremeLabsDashboard,
+      };
+
+      const fetchDashboard = labDashboardOptions[labSummaryTag];
+
+      if (!fetchDashboard) {
+        throw new Error(`Unsupported lab summary tag: ${labSummaryTag}`);
+      }
+
+      const response = await fetchDashboard(classId);
+
+      const url = response?.data?.url || response?.data?.redirect_to;
+
+      if (url) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        const errorMessage = response?.data?.message || response?.data?.error;
+        throw new Error(errorMessage);
+      }
+    } catch (error) {
+      showToast(error.message || 'An unexpected error occurred.');
+      logError(error);
+    }
+  };
+}
+
 export {
   fetchClassesData,
   fetchClassesOptionsData,
   fetchAllClassesData,
+  fetchLabSummaryLink,
 };

--- a/src/hooks/__test__/index.test.jsx
+++ b/src/hooks/__test__/index.test.jsx
@@ -1,7 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import { renderWithProviders } from 'test-utils';
-import { useInstitutionIdQueryParam } from 'hooks';
+import { useInstitutionIdQueryParam, useToast } from 'hooks';
 import { INSTITUTION_QUERY_ID } from 'features/constants';
 
 describe('useInstitutionIdQueryParam', () => {
@@ -47,5 +47,40 @@ describe('useInstitutionIdQueryParam', () => {
     });
 
     expect(result.current('http://example.com?foo=bar')).toBe(`http://example.com?foo=bar&${INSTITUTION_QUERY_ID}=${institutionId}`);
+  });
+});
+
+describe('useToast', () => {
+  test('Should initialize with default toast state', () => {
+    const { result } = renderHook(() => useToast());
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.message).toBe('');
+  });
+
+  test('Should update toast state when showToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showToast('Test message');
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.message).toBe('Test message');
+  });
+
+  test('Should reset toast state when hideToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showToast('Test message');
+    });
+
+    act(() => {
+      result.current.hideToast();
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.message).toBe('');
   });
 });

--- a/src/hooks/index.jsx
+++ b/src/hooks/index.jsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { useState } from 'react';
 
 import { INSTITUTION_QUERY_ID } from 'features/constants';
 
@@ -15,4 +16,36 @@ export const useInstitutionIdQueryParam = () => {
   };
 
   return addQueryParam;
+};
+
+/**
+ * Custom hook to manage toast notifications
+ * @returns {Object} Toast state and methods
+ */
+export const useToast = () => {
+  const [toast, setToast] = useState({
+    isVisible: false,
+    message: '',
+  });
+
+  const showToast = (message) => {
+    setToast({
+      isVisible: true,
+      message,
+    });
+  };
+
+  const hideToast = () => {
+    setToast({
+      isVisible: false,
+      message: '',
+    });
+  };
+
+  return {
+    isVisible: toast.isVisible,
+    message: toast.message,
+    showToast,
+    hideToast,
+  };
 };


### PR DESCRIPTION
## Description

This PR point Lab summary (now renamed Lab Dashboard) to the skillable and Xtreme Lab dashboard directly. From the backend, we retrieve the "skillable-dashboad" or "xtreme-labs-dashboard" tag, that indicates which endpoint is required to consume, to generate the URL that will be used to redirect the user, to the respective external portal.

In case the request fail retrieving the URL, a Toast is used to show the response error message.

## How to test

1. Use the changes in this branch and run "npm start"
2. Run your local openedx environment
3. Use the brabch in this PR: https://github.com/Pearson-Advance/course_operations/pull/359 to retrieve the lab summary tag
4. Go to the portal, in a class details, and click on the Lab Dashboard button
![image](https://github.com/user-attachments/assets/d0ce0047-7489-4d54-b422-d5c410375a62)
5. For "skillable-dashboad" or "xtreme-labs-dashboard" tag, will open a new window to the external dashboard if the request got a URL. Examples:

* Skillable dashboard
![image](https://github.com/user-attachments/assets/845d98bb-21fd-4b46-a8a0-3a5e83b637a6)

* xtreme labs dashboard
![image](https://github.com/user-attachments/assets/c308b010-671c-4598-b87e-17b972fb39c8)


6. In case skillable or xtreme labs are no available in other course settings for the class, the button "Lab Dashboard" will not be rendering in the dropdown

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-2203