### PR TITLE
PADV-2331: Fix Filters on Student Page

### DIFF
--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -142,7 +142,7 @@ const StudentsFilters = ({ resetPagination }) => {
               <Form.Group as={Col}>
                 <Select
                   placeholder="Course"
-                  name="course_name"
+                  name="course_id"
                   className="mr-2"
                   options={courseOptions}
                   onChange={option => setCourseSelected(option)}


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-2331

# Description

Filters on Student Page are not working correctly. So this PR addresses the error and switch course_name by course_id parameter.


## Change log
- Modify Student Filter

### How to test
- Start the services.
- Enter in CertPREP Manager
- Filter by course and class
- Make sure data is filtered correctly