### PR TITLE
PADV-2344 feat: remove tz from class event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.29.0",
+        "react-paragon-topaz": "^1.30.0",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17324,9 +17324,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.29.0.tgz",
-      "integrity": "sha512-W02pA2y2XG0dnA1fgLZvHB2GKn4Ced42noEJFIa898O6TWgdbciSlZoX4PBZhB0WMT6Y/wuDwdLoePs32WXE7g==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.30.0.tgz",
+      "integrity": "sha512-zwoLzgk5qGzGIeX047Yq8hHyax9Z8MeD2LZ8l9h7ebAkuWKs7Snfdj9Z6RJZn0ZDvfH8sdZf55a/Cw8haA7Agg==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "^1.29.0",
+    "react-paragon-topaz": "^1.30.0",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/features/Instructors/InstructorsDetailPage/index.jsx
+++ b/src/features/Instructors/InstructorsDetailPage/index.jsx
@@ -12,8 +12,10 @@ import {
   Tabs,
   Tab,
 } from '@edx/paragon';
-import { CalendarExpanded, ProfileCard, formatUTCDate } from 'react-paragon-topaz';
-import { startOfMonth, endOfMonth } from 'date-fns';
+import {
+  CalendarExpanded, ProfileCard, formatUTCDate, parseUTCDateWithoutTZ,
+} from 'react-paragon-topaz';
+import { startOfMonth, endOfMonth, endOfDay } from 'date-fns';
 
 import Table from 'features/Main/Table';
 import { fetchClassesData } from 'features/Classes/data/thunks';
@@ -132,15 +134,26 @@ const InstructorsDetailPage = () => {
   }, [institution, history, addQueryParam]);
 
   useEffect(() => {
-    if (events.length > 0) {
-      const list = events?.map(event => ({
-        ...event,
-        start: new Date(event.start),
-        end: new Date(event.end),
-      }));
+    if (!Array.isArray(events) || events.length === 0) { return; }
 
-      setEventsList(list);
-    }
+    const list = events.map(event => {
+      const { start, end, isClass } = event;
+
+      if (isClass) {
+        return {
+          ...event,
+          start: parseUTCDateWithoutTZ(start),
+          end: endOfDay(parseUTCDateWithoutTZ(end)),
+        };
+      }
+
+      return {
+        ...event,
+        start: new Date(start),
+        end: new Date(end),
+      };
+    });
+    setEventsList(list);
   }, [events]);
 
   return (


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2344

### Description
In the calendar availability the classes events begin one day before the date defined. This behavior is related to timezone, as the calendar component needs a date object, when the browser convert from string to date it take the local timezone. So to fix it, we have to remove the hour from the utc string and make the date with the year, month and day, this is done in the library: https://github.com/Pearson-Advance/react-paragon-topaz-library/pull/61

### Changes made
Update react-topaz library version
Change start and end date to be without tz if is a class

### Screenshoot
![Screenshot from 2025-05-14 12-11-16](https://github.com/user-attachments/assets/f03990d4-498c-4fd0-bb84-a9ac3b49b04a)
![Screenshot from 2025-05-14 12-11-46](https://github.com/user-attachments/assets/1cb9bce5-c1bc-4175-a1e5-778d25fb1e2d)


### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/
