### PR TITLE
feat: active status toggle filter in instructors filters

### DIFF
--- a/src/features/Instructors/InstructorsFilters/__test__/index.test.jsx
+++ b/src/features/Instructors/InstructorsFilters/__test__/index.test.jsx
@@ -1,84 +1,122 @@
 import React from 'react';
 import { fireEvent, act } from '@testing-library/react';
-import InstructorsFilters from 'features/Instructors/InstructorsFilters';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+
+import InstructorsFilters from 'features/Instructors/InstructorsFilters';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    SHOW_INSTRUCTOR_FEATURES: true,
+  })),
+}));
+
 describe('InstructorsFilters Component', () => {
   const resetPagination = jest.fn();
-  const mockSetFilters = jest.fn();
+
+  const setup = (props = {}) => renderWithProviders(
+    <InstructorsFilters resetPagination={resetPagination} {...props} />,
+  );
 
   beforeEach(() => {
-    mockSetFilters.mockClear();
+    jest.clearAllMocks();
   });
 
-  test('render name input and call service when apply filters', async () => {
-    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
-      <InstructorsFilters
-        resetPagination={resetPagination}
-      />,
-    );
+  test('Should render the name input and applies filters', async () => {
+    const { getByTestId, getByText } = setup();
 
-    expect(getByPlaceholderText('Enter Instructor Name')).toBeInTheDocument();
-    expect(getByText('Course')).toBeInTheDocument();
+    const nameInput = getByTestId('instructorName');
+    const applyButton = getByText('Apply');
 
-    const inputName = getByTestId('instructorName');
-    const buttonApplyFilters = getByText('Apply');
-
-    fireEvent.change(inputName, {
-      target: { value: 'Jhon Doe' },
-    });
-
-    expect(inputName).toHaveValue('Jhon Doe');
+    fireEvent.change(nameInput, { target: { value: 'Jane Doe' } });
+    expect(nameInput).toHaveValue('Jane Doe');
 
     await act(async () => {
-      fireEvent.click(buttonApplyFilters);
+      fireEvent.click(applyButton);
     });
   });
 
-  test('render email input', async () => {
-    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
-      <InstructorsFilters
-        resetPagination={resetPagination}
-      />,
-    );
+  test('Should switch to email input and applies filters', async () => {
+    const { getByTestId, getByText } = setup();
 
-    const checkbox = getByTestId('emailCheckbox');
-    const buttonApplyFilters = getByText('Apply');
+    fireEvent.click(getByTestId('emailCheckbox'));
 
-    fireEvent.click(checkbox);
+    const emailInput = getByTestId('instructorEmail');
+    expect(emailInput).toBeInTheDocument();
 
-    expect(getByPlaceholderText('Enter Instructor Email')).toBeInTheDocument();
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
 
     await act(async () => {
-      fireEvent.click(buttonApplyFilters);
+      fireEvent.click(getByText('Apply'));
     });
   });
 
-  test('Clear filters', async () => {
-    const { getByPlaceholderText, getByText } = renderWithProviders(
-      <InstructorsFilters
-        resetPagination={resetPagination}
-      />,
-    );
+  test('Should reset the fields and filters', async () => {
+    const { getByTestId, getByText } = setup();
 
-    const nameInput = getByPlaceholderText('Enter Instructor Name');
-    const buttonClearFilters = getByText('Reset');
+    const nameInput = getByTestId('instructorName');
+    fireEvent.change(nameInput, { target: { value: 'Reset Me' } });
+    expect(nameInput).toHaveValue('Reset Me');
 
-    expect(nameInput).toBeInTheDocument();
-
-    fireEvent.change(nameInput, { target: { value: 'Name' } });
-
-    expect(nameInput).toHaveValue('Name');
+    const resetButton = getByText('Reset');
 
     await act(async () => {
-      fireEvent.click(buttonClearFilters);
+      fireEvent.click(resetButton);
     });
 
     expect(nameInput).toHaveValue('');
+  });
+
+  test('renders course select when not in assign mode', () => {
+    const { getByText, getByRole } = setup();
+
+    expect(getByText('Course')).toBeInTheDocument();
+    expect(getByRole('combobox')).toBeInTheDocument();
+  });
+
+  describe('Assign mode', () => {
+    test('hides course select and switch', () => {
+      const { queryByText, queryByRole } = setup({ isAssignSection: true });
+
+      expect(queryByText('Course')).not.toBeInTheDocument();
+      expect(queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('disables apply and reset buttons when fields are empty', () => {
+      const { getByText } = setup({ isAssignSection: true });
+
+      expect(getByText('Apply')).toBeDisabled();
+      expect(getByText('Reset')).toBeDisabled();
+    });
+
+    test('enables apply button when email is filled', () => {
+      const { getByTestId, getByText } = setup({ isAssignSection: true });
+
+      fireEvent.click(getByTestId('emailCheckbox'));
+
+      const emailInput = getByTestId('instructorEmail');
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+
+      expect(getByText('Apply')).not.toBeDisabled();
+    });
+  });
+
+  describe('Feature flag active filter', () => {
+    test('renders active filter switches', () => {
+      const { getByText } = setup();
+
+      expect(getByText(/Instructor status:/)).toBeInTheDocument();
+    });
+
+    test('toggles active filter switches', () => {
+      const { getByText } = setup();
+
+      const toggleLabel = getByText(/Instructor status:/);
+      expect(toggleLabel).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
# Description

This PR enhances the `InstructorsFilters` component by introducing a new toggle switch that filters instructors based on their active status. This switch is conditionally rendered when the `SHOW_INSTRUCTOR_FEATURES` flag is `enabled`. To improve performance and reduce unnecessary server load, a debounce mechanism has been implemented on the filters request. Unit tests have been updated to reflect all relevant component states, including additional test cases for the newly introduced filter.

## Ticket
[PADV-2348](https://agile-jira.pearson.com/browse/PADV-2348)

## Visual results
![image](https://github.com/user-attachments/assets/4bae78e2-7657-4ffb-afe4-0c2511c571ff)


## How to test
- Enable `SHOW_INSTRUCTOR_FEATURES` in the site config.
- Go to `/instructors`, use the filters