### PR TITLE
PADV-1603 feat: list only active instructors

### DIFF
--- a/src/features/Instructors/InstructorsFilters/index.jsx
+++ b/src/features/Instructors/InstructorsFilters/index.jsx
@@ -57,7 +57,14 @@ const InstructorsFilters = ({ resetPagination, isAssignSection }) => {
   const config = inputConfig[formState.inputType] || {};
 
   const handleCleanFilters = () => {
-    dispatch(fetchInstructorsData(selectedInstitution?.id));
+    const requestPayload = isAssignSection ? { active: true } : undefined;
+
+    dispatch(fetchInstructorsData(
+      selectedInstitution?.id,
+      initialPage,
+      requestPayload,
+    ));
+
     resetPagination();
     dispatch(updateFilters({}));
     resetFields();
@@ -85,6 +92,7 @@ const InstructorsFilters = ({ resetPagination, isAssignSection }) => {
     const requestPayload = {
       ...filters[inputType],
       course_name: courseSelected?.masterCourseName || '',
+      active: isAssignSection ? true : undefined,
     };
 
     dispatch(updateFilters(filters));

--- a/src/features/Instructors/ManageInstructors/AssignSection.jsx
+++ b/src/features/Instructors/ManageInstructors/AssignSection.jsx
@@ -62,7 +62,10 @@ const AssignSection = forwardRef((props, ref) => {
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
-      const instructorFilters = stateInstructors.filters;
+      const instructorFilters = {
+        ...stateInstructors.filters,
+        active: true,
+      };
       dispatch(fetchInstructorsData(selectedInstitution.id, currentPage, instructorFilters));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1603

### Description
Show only active instructors in manage instructors page

### Changes made
Send query param for active true in services when is the manage instructor page

### Screenshoot
![Screenshot from 2025-05-21 16-28-35](https://github.com/user-attachments/assets/224c45fc-3fc6-4da0-a4de-cedafd577d56)
![Screenshot from 2025-05-21 16-28-55](https://github.com/user-attachments/assets/af8a5109-9824-409c-95d7-ac0a62eb810c)


### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/

Note: By default all instructors are active, that is the reason there is not need to conditionally this change with the site configuration, the query param doesn't affect the current behavior