### PR TITLE
PADV-2386 feat: activate filter with only two states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "1.33.0",
+        "react-paragon-topaz": "^1.35.0",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17324,9 +17324,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.33.0.tgz",
-      "integrity": "sha512-2MSz5F5oq37zj9ATgMCPgBZl8mY16ttUnPWiQ0LLhgFXEOnsejMeKwJCJkDILwkP1o4YP4FW20lU7/9CqRNtgw==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.35.0.tgz",
+      "integrity": "sha512-nTCYgJ2zf13RxTsOYsny+X3qeIumYiQnxA1bj5CoOmhaEYQDSsoKZTv/wZPOZCimz2eaPBbE/3Bi1F8QPcsteA==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "1.33.0",
+    "react-paragon-topaz": "1.35.0",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/features/Instructors/InstructorsPage/index.jsx
+++ b/src/features/Instructors/InstructorsPage/index.jsx
@@ -21,7 +21,7 @@ const InstructorsPage = () => {
 
   useEffect(() => {
     if (Object.keys(selectedInstitution).length > 0) {
-      dispatch(fetchInstructorsData(selectedInstitution.id, currentPage));
+      dispatch(fetchInstructorsData(selectedInstitution.id, currentPage, { active: true }));
     }
 
     return () => {


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2386

### Description
Have only active/inactive states in instructors filters

### Changes made
Remove null stage
The apply button will be disabled until active filter is touched or other filter has information
Compare filter info to only send service call when data change and avoid unnecessary calls
By default instructor list will show active instructors

### Screenshoot
![activefilter](https://github.com/user-attachments/assets/f59d673c-b4a4-48ef-bad8-485142dd4c11)

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/

Note: By default all instructors are active, that is the reason there is not need to conditionally this change with the site configuration, the query param doesn't affect the current behavior