### PR TITLE
feat: add DeleteEnrollment functionallity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "1.36.0",
+        "react-paragon-topaz": "1.38.0",
         "react-redux": "^7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -17324,9 +17324,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.36.0.tgz",
-      "integrity": "sha512-QAQvnmr3XO+9ZLhEkZqW2e7Ksgl6kz6uo3tG32TJzIb6oVnYyEYhWow46jVYVqvRuMgnPbod4vGASSJeRCxGVQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.38.0.tgz",
+      "integrity": "sha512-8aRPx+zYTWVHWCggWQggnYa//Y5gBOZ0Ov0UodeYqmI161RBDHdlx+veN5v8nyl67mUVtlU+o5KLpyRKYmK16w==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "1.36.0",
+    "react-paragon-topaz": "1.38.0",
     "react-redux": "^7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -12,6 +12,7 @@ import { MoreHoriz } from '@edx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
 
 import { useInstitutionIdQueryParam } from 'hooks';
+import DeleteEnrollment from 'features/Main/DeleteEnrollment';
 
 const columns = [
   {
@@ -75,7 +76,14 @@ const columns = [
     cellClassName: 'dropdownColumn',
     disableSortBy: true,
     Cell: ({ row }) => {
-      const { classId, userId } = row.original;
+      const {
+        status,
+        classId,
+        userId,
+        courseId,
+        learnerEmail,
+      } = row.original;
+
       const progressPageLink = `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classId}/progress/${userId}`;
       return (
         <Dropdown className="dropdowntpz">
@@ -98,6 +106,11 @@ const columns = [
               <i className="fa-regular fa-bars-progress mr-2" />
               View progress
             </Dropdown.Item>
+            {
+              status?.toLowerCase() !== 'expired' && (
+                <DeleteEnrollment studentEmail={learnerEmail} courseId={courseId} />
+              )
+            }
           </Dropdown.Menu>
         </Dropdown>
       );

--- a/src/features/Classes/Class/ClassPage/index.jsx
+++ b/src/features/Classes/Class/ClassPage/index.jsx
@@ -36,6 +36,8 @@ const ClassPage = () => {
   const courseIdDecoded = decodeURIComponent(courseId);
   const classIdDecoded = decodeURIComponent(classId);
 
+  const COLUMNS = useMemo(() => columns, []);
+
   const institutionRef = useRef(undefined);
   const [currentPage, setCurrentPage] = useState(initialPage);
   const institution = useSelector((state) => state.main.selectedInstitution);
@@ -126,7 +128,7 @@ const ClassPage = () => {
           </div>
           <Table
             isLoading={isLoadingStudents}
-            columns={columns}
+            columns={COLUMNS}
             count={students.count}
             data={students.data}
             text="No students were found for this class."

--- a/src/features/Main/DeleteEnrollment/__test__/index.test.jsx
+++ b/src/features/Main/DeleteEnrollment/__test__/index.test.jsx
@@ -1,0 +1,284 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import {
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { Dropdown } from '@edx/paragon';
+import '@testing-library/jest-dom/extend-expect';
+
+import { renderWithProviders } from 'test-utils';
+import { deleteEnrollment } from 'features/Main/data/api';
+import DeleteEnrollment from 'features/Main/DeleteEnrollment';
+
+jest.mock('features/Main/data/api', () => ({
+  deleteEnrollment: jest.fn(),
+}));
+
+const mockDeleteEnrollment = deleteEnrollment;
+
+const createMockStore = (studentEmail = 'testuser@example.com') => ({
+  main: {
+    selectedInstitution: {
+      id: 1,
+    },
+  },
+  students: {
+    table: {
+      next: null,
+      previous: null,
+      count: 1,
+      numPages: 1,
+      currentPage: 1,
+      start: 0,
+      data: [
+        {
+          learnerName: 'Test User',
+          learnerEmail: studentEmail,
+          courseId: 'course-v1:demo+demo1+2020',
+          courseName: 'Demo Course 1',
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+          className: 'test ccx1',
+          created: '2024-02-13T18:31:27.399407Z',
+          status: 'Active',
+          examReady: false,
+          startDate: '2024-02-13T17:42:22Z',
+          endDate: null,
+          completePercentage: 0.0,
+        },
+      ],
+    },
+  },
+});
+
+const defaultProps = {
+  studentEmail: 'test@example.com',
+  courseId: 'course-v1:demo+demo1+2020',
+};
+
+const renderDeleteEnrollment = (props = {}, storeOverrides = {}) => {
+  const finalProps = { ...defaultProps, ...props };
+  const mockStore = createMockStore(finalProps.studentEmail);
+  const finalStore = { ...mockStore, ...storeOverrides };
+
+  return renderWithProviders(
+    <Dropdown className="dropdowntpz">
+      <Dropdown.Toggle
+        id="dropdown-toggle-with-iconbutton"
+        variant="primary"
+        data-testid="dropdown-action"
+        alt="menu for actions"
+      />
+      <Dropdown.Menu>
+        <DeleteEnrollment {...finalProps} />
+      </Dropdown.Menu>
+    </Dropdown>,
+    { preloadedState: finalStore },
+  );
+};
+
+const openDropdown = () => {
+  const dropdownToggle = screen.getByTestId('dropdown-action');
+  fireEvent.click(dropdownToggle);
+};
+
+const openConfirmationModal = () => {
+  openDropdown();
+
+  waitFor(() => {
+    const modalTrigger = screen.getByTestId('delete-enrollment');
+    fireEvent.click(modalTrigger);
+  });
+};
+
+const proceedWithDeletion = () => {
+  const proceedButton = screen.getByText('Proceed');
+
+  fireEvent.click(proceedButton);
+};
+
+describe('DeleteEnrollment Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initial Render', () => {
+    test('should render delete enrollment dropdown item when dropdown is opened', () => {
+      renderDeleteEnrollment();
+
+      openDropdown();
+
+      const deleteItems = screen.getAllByText('Delete Enrollment');
+      expect(deleteItems.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Confirmation Modal', () => {
+    test('should open confirmation modal when delete enrollment is clicked', () => {
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+
+      expect(screen.getByText(/You are attempting to unenroll a student./i)).toBeInTheDocument();
+      expect(screen.getByText(/Do you wish to proceed?/i)).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+      expect(screen.getByText('Proceed')).toBeInTheDocument();
+    });
+
+    test('should close confirmation modal when cancel is clicked', () => {
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByText(/You are attempting to unenroll a student./i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Successful Enrollment Deletion', () => {
+    test('should show success toast and update store when deletion is successful', async () => {
+      mockDeleteEnrollment.mockResolvedValueOnce({
+        data: { results: [{}] },
+      });
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('toast-message')).toHaveTextContent('Enrollment deleted successfully.');
+      });
+
+      expect(mockDeleteEnrollment).toHaveBeenCalledWith(
+        defaultProps.studentEmail,
+        defaultProps.courseId,
+      );
+    });
+
+    test('should show processing state while deletion is in progress', async () => {
+      let resolvePromise;
+      mockDeleteEnrollment.mockReturnValueOnce(
+        new Promise(resolve => { resolvePromise = resolve; }),
+      );
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      expect(screen.getByText('Processing...')).toBeInTheDocument();
+      expect(screen.getByText('Processing...')).toBeDisabled();
+
+      resolvePromise({ data: { results: [{}] } });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Processing...')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('should show threshold error modal when API returns error result', async () => {
+      mockDeleteEnrollment.mockResolvedValueOnce({
+        data: { results: [{ error: true }] },
+      });
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(screen.getByText(/This student has reached a threshold of course activity/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('Dismiss')).toBeInTheDocument();
+    });
+
+    test('should show generic error modal when API throws unexpected error', async () => {
+      mockDeleteEnrollment.mockRejectedValueOnce(new Error('Network error'));
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Unexpected error occurred. Please try again later./i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('Dismiss')).toBeInTheDocument();
+    });
+
+    test('should reset all modals when dismiss button is clicked on error modal', async () => {
+      mockDeleteEnrollment.mockRejectedValueOnce(new Error('Network error'));
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Unexpected error occurred. Please try again later./i)).toBeInTheDocument();
+      });
+
+      const dismissButton = screen.getByText('Dismiss');
+      fireEvent.click(dismissButton);
+
+      expect(screen.queryByText('Error')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Unexpected error occurred. Please try again later./i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Toast Functionality', () => {
+    test('should close success toast when close button is triggered', async () => {
+      mockDeleteEnrollment.mockResolvedValueOnce({
+        data: { results: [{}] },
+      });
+
+      renderDeleteEnrollment();
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('toast-message')).toBeInTheDocument();
+      });
+
+      const toast = screen.getByTestId('toast-message');
+      fireEvent.click(toast);
+
+      expect(screen.getByTestId('toast-message')).toBeInTheDocument();
+    });
+  });
+
+  describe('API Integration', () => {
+    test('should call deleteEnrollment API with correct parameters', async () => {
+      mockDeleteEnrollment.mockResolvedValueOnce({
+        data: { results: [{}] },
+      });
+
+      const customProps = {
+        studentEmail: 'custom@test.com',
+        courseId: 'custom-course-id',
+      };
+
+      renderDeleteEnrollment(customProps);
+
+      openConfirmationModal();
+      proceedWithDeletion();
+
+      await waitFor(() => {
+        expect(mockDeleteEnrollment).toHaveBeenCalledWith(
+          customProps.studentEmail,
+          customProps.courseId,
+        );
+      });
+    });
+  });
+});

--- a/src/features/Main/DeleteEnrollment/index.jsx
+++ b/src/features/Main/DeleteEnrollment/index.jsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import {
+  Dropdown,
+  Toast,
+  useToggle,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  ConfirmationModal,
+  UNENROLL_MESSAGE,
+  CONFIRMATION_UNENROLL_MESSAGE,
+  UNENROLL_ERROR_MESSAGE,
+} from 'react-paragon-topaz';
+
+import {
+  fetchStudentsDataSuccess,
+} from 'features/Students/data/slice';
+import { deleteEnrollment } from 'features/Main/data/api';
+
+/**
+ * DeleteEnrollment allows an administrator to unenroll a student from a course.
+ * It handles confirmation, API interaction, error display, and feedback toast.
+ *
+ * Props:
+ * @param {string} studentEmail - The email of the student to unenroll.
+ * @param {string} courseId - The ID of the course from which to unenroll the student.
+ */
+const DeleteEnrollment = ({ studentEmail, courseId }) => {
+  const [message, setMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dispatch = useDispatch();
+  const students = useSelector((state) => state.students.table.data);
+
+  const [isError, openError, closeError] = useToggle(false);
+  const [isConfirmationOpen, openConfirmation, closeConfirmation] = useToggle(false);
+  const [showSuccessToast, openSuccessToast, closeSuccessToast] = useToggle(false);
+
+  const resetModals = () => {
+    setMessage('');
+    closeConfirmation();
+    closeSuccessToast();
+    closeError();
+    setIsSubmitting(false);
+  };
+
+  const handleDeleteEnrollment = async () => {
+    setIsSubmitting(true);
+    try {
+      const response = await deleteEnrollment(studentEmail, courseId);
+      const result = response?.data?.results?.[0];
+
+      if (result?.error) {
+        setMessage(UNENROLL_ERROR_MESSAGE);
+        openError();
+      } else {
+        const updatedStudents = students.filter(
+          (student) => student.learnerEmail !== studentEmail,
+        );
+
+        dispatch(fetchStudentsDataSuccess({
+          results: updatedStudents,
+          count: updatedStudents.length,
+        }));
+
+        setMessage('Enrollment deleted successfully.');
+        closeConfirmation();
+        openSuccessToast();
+      }
+    } catch {
+      setMessage('Unexpected error occurred. Please try again later.');
+      openError();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dropdown.Item
+        className="text-truncate text-decoration-none text-danger"
+        onClick={openConfirmation}
+        data-testid="delete-enrollment"
+      >
+        <i className="fa-regular fa-trash mr-2 mb-1" />
+        Delete Enrollment
+      </Dropdown.Item>
+
+      <ConfirmationModal
+        title="Delete Enrollment"
+        isOpen={isConfirmationOpen && !isError}
+        onClose={closeConfirmation}
+        onConfirm={handleDeleteEnrollment}
+        confirmLabel="Proceed"
+        cancelLabel="Cancel"
+        isFullscreenOnMobile
+        isSubmitting={isSubmitting}
+      >
+        {UNENROLL_MESSAGE}
+        <br />
+        <br />
+        {CONFIRMATION_UNENROLL_MESSAGE}
+      </ConfirmationModal>
+
+      <ConfirmationModal
+        title="Error"
+        isOpen={isError}
+        onClose={resetModals}
+        hasCloseButton
+        isFullscreenOnMobile
+        message={message}
+        isSubmitting={false}
+        onConfirm={resetModals}
+        showCancelButton={false}
+        confirmLabel="Dismiss"
+      />
+
+      <Toast
+        onClose={closeSuccessToast}
+        show={showSuccessToast}
+        className="toast-message"
+        data-testid="toast-message"
+      >
+        {message}
+      </Toast>
+    </>
+  );
+};
+
+DeleteEnrollment.propTypes = {
+  studentEmail: PropTypes.string.isRequired,
+  courseId: PropTypes.string.isRequired,
+};
+
+export default DeleteEnrollment;

--- a/src/features/Main/data/api.js
+++ b/src/features/Main/data/api.js
@@ -26,7 +26,21 @@ function assignStaffRole(classId) {
   );
 }
 
+function deleteEnrollment(studentEmail, courseId) {
+  const BASE_URL = getConfig().LMS_BASE_URL;
+
+  const formData = new FormData();
+  formData.append('identifiers', studentEmail);
+  formData.append('action', 'unenroll');
+
+  return getAuthenticatedHttpClient().post(
+    `${BASE_URL}/courses/${courseId}/instructor/api/students_update_enrollment`,
+    formData,
+  );
+}
+
 export {
   getInstitutionName,
   assignStaffRole,
+  deleteEnrollment,
 };

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -11,6 +11,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { Badge, STUDENT_STATUS_VARIANTS } from 'react-paragon-topaz';
 
 import LinkWithQuery from 'features/Main/LinkWithQuery';
+import DeleteEnrollment from 'features/Main/DeleteEnrollment';
 
 import { formatUTCDate } from 'helpers';
 import { useInstitutionIdQueryParam } from 'hooks';
@@ -91,8 +92,15 @@ const columns = [
     cellClassName: 'dropdownColumn',
     disableSortBy: true,
     Cell: ({ row }) => {
-      const { classId, userId } = row.original;
+      const {
+        classId,
+        userId,
+        courseId,
+        learnerEmail,
+      } = row.original;
+
       const progressPageLink = `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classId}/progress/${userId}`;
+
       return (
         <Dropdown className="dropdowntpz">
           <Dropdown.Toggle
@@ -114,6 +122,11 @@ const columns = [
               <i className="fa-regular fa-bars-progress mr-2" />
               View progress
             </Dropdown.Item>
+            {
+              row.values.status?.toLowerCase() !== 'expired' && (
+                <DeleteEnrollment studentEmail={learnerEmail} courseId={courseId} />
+              )
+            }
           </Dropdown.Menu>
         </Dropdown>
       );

--- a/src/features/Students/data/slice.js
+++ b/src/features/Students/data/slice.js
@@ -38,7 +38,7 @@ export const studentsSlice = createSlice({
       const { results, count, numPages } = payload;
       state.table.status = RequestStatus.SUCCESS;
       state.table.data = results;
-      state.table.numPages = numPages;
+      state.table.numPages = numPages || state.table.numPages;
       state.table.count = count;
     },
     fetchStudentsDataFailed: (state) => {


### PR DESCRIPTION
# Description

This PR adds the functionality  to delete an enrollment.

## Ticket
https://pearson.atlassian.net/browse/PADV-2108

## Visual results
![delete-enrollment-3](https://github.com/user-attachments/assets/d4f73853-1229-4e57-96bf-0a02925f098d)
![delete-enrollment-2](https://github.com/user-attachments/assets/f6cea742-984b-44de-b6fb-e2938bf98a71)
![delete-enrollment](https://github.com/user-attachments/assets/9c9fcc4a-a315-4365-a5b8-535376d57c88)



## How to test

Configure this locally or just override the http request using the info provided here:

https://github.com/Pearson-Advance/course_operations/pull/380