### PR TITLE
PADV-2218 feat: add IP link for intructor role

### DIFF
--- a/src/features/Main/Sidebar/_test_/index.test.jsx
+++ b/src/features/Main/Sidebar/_test_/index.test.jsx
@@ -3,6 +3,7 @@ import { fireEvent } from '@testing-library/react';
 import { Sidebar } from 'features/Main/Sidebar';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
+import * as paragonTopaz from 'react-paragon-topaz';
 
 const mockHistoryPush = jest.fn();
 
@@ -16,8 +17,19 @@ jest.mock('react-router', () => ({
   }),
 }));
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    INSTRUCTOR_PORTAL_PATH: 'https://instructor.example.com',
+  })),
+}));
+
+jest.mock('react-paragon-topaz', () => ({
+  ...jest.requireActual('react-paragon-topaz'),
+  getUserRoles: jest.fn(() => (['INSTITUTION_ADMIN'])),
+}));
+
 describe('Sidebar', () => {
-  it('should render properly', () => {
+  test('should render properly', () => {
     const { getByRole } = renderWithProviders(
       <Sidebar />,
     );
@@ -29,5 +41,17 @@ describe('Sidebar', () => {
     expect(studentsTabButton).toHaveClass('active');
 
     expect(mockHistoryPush).toHaveBeenCalledWith('/students');
+  });
+
+  test('should render Instructor Portal item if has role', () => {
+    paragonTopaz.getUserRoles.mockReturnValue(['INSTRUCTOR', 'INSTITUTION_ADMIN']);
+
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+    );
+
+    const portalLink = getByText('Instructor Portal');
+
+    expect(portalLink).toBeInTheDocument();
   });
 });

--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { getConfig } from '@edx/frontend-platform';
 
 import {
   Sidebar as SidebarBase,
   MenuSection,
   MenuItem,
   SIDEBAR_HELP_ITEMS,
+  getUserRoles,
+  USER_ROLES,
 } from 'react-paragon-topaz';
 
 import { updateActiveTab } from 'features/Main/data/slice';
@@ -15,7 +18,7 @@ import { useInstitutionIdQueryParam } from 'hooks';
 
 import './index.scss';
 
-const menuItems = [
+const baseItems = [
   {
     link: 'dashboard',
     label: 'Home',
@@ -51,7 +54,22 @@ const menuItems = [
 export const Sidebar = () => {
   const history = useHistory();
   const dispatch = useDispatch();
+  const roles = getUserRoles();
   const activeTab = useSelector((state) => state.main.activeTab);
+  const menuItems = [...baseItems];
+  const instructorPortalPath = getConfig().INSTRUCTOR_PORTAL_PATH || '';
+
+  if (roles.includes(USER_ROLES.INSTRUCTOR) && instructorPortalPath.length > 0) {
+    menuItems.push({
+      link: 'instructor-portal',
+      as: 'a',
+      href: instructorPortalPath,
+      label: 'Instructor Portal',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      icon: <i className="fa-regular fa-person-chalkboard" />,
+    });
+  }
 
   const handleTabClick = (tabName) => {
     dispatch(updateActiveTab(tabName));
@@ -65,16 +83,34 @@ export const Sidebar = () => {
     <SidebarBase>
       <MenuSection>
         {
-          menuItems.map(({ link, label, icon }) => (
-            <MenuItem
-              key={link}
-              title={label}
-              path={addQueryParam(link)}
-              active={currentSelection === link}
-              onClick={handleTabClick}
-              icon={icon}
-            />
-          ))
+          menuItems.map(({
+            link, label, icon, as, href, target, rel,
+          }) => {
+            if (as === 'a') {
+              return (
+                <MenuItem
+                  key={link}
+                  title={label}
+                  as={as}
+                  href={href}
+                  icon={icon}
+                  target={target}
+                  rel={rel}
+                />
+              );
+            }
+
+            return (
+              <MenuItem
+                key={link}
+                title={label}
+                path={addQueryParam(link)}
+                active={currentSelection === link}
+                onClick={handleTabClick}
+                icon={icon}
+              />
+            );
+          })
         }
       </MenuSection>
       <MenuSection title="Help and support">


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2218

### Description
Add link to IP portal when the user has instructor role

### Changes made
Include link to IP portal when user has intructor role
If the item is a link element will render different the menu item in the sidebar
update test

### Screenshoot
![Screenshot from 2025-06-04 10-13-32](https://github.com/user-attachments/assets/4dca6969-d29a-47c4-a1e6-e3e857b06ca7)

How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/

Required:
Go to site configuration, in MFE_CONFIG add this variable:
"INSTRUCTOR_PORTAL_PATH": "/instructor",

Note: Locally it won't open the IP because is different port but you will see that will open in the same base url and then the instructor portal path defined