### PR TITLE
feat: add email column to instructors table in assign instructors view

### DIFF
--- a/src/features/Instructors/ManageInstructors/_test_/columns.test.jsx
+++ b/src/features/Instructors/ManageInstructors/_test_/columns.test.jsx
@@ -5,16 +5,20 @@ import { columns } from 'features/Instructors/ManageInstructors/columns';
 describe('columns', () => {
   test('Should return an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(3);
+    expect(columns).toHaveLength(4);
 
     const [
       instructor,
+      instructorEmail,
       lastSeen,
       coursesTaught,
     ] = columns;
 
     expect(instructor).toHaveProperty('Header', 'Instructor');
     expect(instructor).toHaveProperty('accessor', 'instructorName');
+
+    expect(instructorEmail).toHaveProperty('Header', 'Email');
+    expect(instructorEmail).toHaveProperty('accessor', 'instructorEmail');
 
     expect(lastSeen).toHaveProperty('Header', 'Last seen');
     expect(lastSeen).toHaveProperty('accessor', 'lastAccess');

--- a/src/features/Instructors/ManageInstructors/columns.jsx
+++ b/src/features/Instructors/ManageInstructors/columns.jsx
@@ -9,6 +9,18 @@ const columns = [
     accessor: 'instructorName',
   },
   {
+    Header: 'Email',
+    accessor: 'instructorEmail',
+    Cell: ({ row }) => (
+      <a
+        href={`mailto:${row.values.instructorEmail}`}
+        className="link"
+      >
+        {row.values.instructorEmail}
+      </a>
+    ),
+  },
+  {
     Header: 'Last seen',
     accessor: 'lastAccess',
     Cell: ({ row }) => {


### PR DESCRIPTION
# Description

In this PR is added the instructor email column in assign instructor page.

## Ticket
https://agile-jira.pearson.com/browse/PADV-2224

## Visual results 
_Before_
![before](https://github.com/user-attachments/assets/abbf703a-c62f-4483-9f66-27e42ce0a4c2)


_After_
![after](https://github.com/user-attachments/assets/ebc7f143-808d-42fb-b153-8c4af7ed71eb)



## How to test.

- Start services
- Go to assign instructors page