### PR TITLE
fix: rename courseId to classId in DeleteEnrollment component

### DIFF
--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -80,7 +80,6 @@ const columns = [
         status,
         classId,
         userId,
-        courseId,
         learnerEmail,
       } = row.original;
 
@@ -108,7 +107,7 @@ const columns = [
             </Dropdown.Item>
             {
               status?.toLowerCase() !== 'expired' && (
-                <DeleteEnrollment studentEmail={learnerEmail} courseId={courseId} />
+                <DeleteEnrollment studentEmail={learnerEmail} classId={classId} />
               )
             }
           </Dropdown.Menu>

--- a/src/features/Main/DeleteEnrollment/__test__/index.test.jsx
+++ b/src/features/Main/DeleteEnrollment/__test__/index.test.jsx
@@ -54,7 +54,7 @@ const createMockStore = (studentEmail = 'testuser@example.com') => ({
 
 const defaultProps = {
   studentEmail: 'test@example.com',
-  courseId: 'course-v1:demo+demo1+2020',
+  classId: 'ccx:class-v1:demo+demo1+2020',
 };
 
 const renderDeleteEnrollment = (props = {}, storeOverrides = {}) => {
@@ -154,7 +154,7 @@ describe('DeleteEnrollment Component', () => {
 
       expect(mockDeleteEnrollment).toHaveBeenCalledWith(
         defaultProps.studentEmail,
-        defaultProps.courseId,
+        defaultProps.classId,
       );
     });
 
@@ -265,7 +265,7 @@ describe('DeleteEnrollment Component', () => {
 
       const customProps = {
         studentEmail: 'custom@test.com',
-        courseId: 'custom-course-id',
+        classId: 'custom-class-id',
       };
 
       renderDeleteEnrollment(customProps);
@@ -276,7 +276,7 @@ describe('DeleteEnrollment Component', () => {
       await waitFor(() => {
         expect(mockDeleteEnrollment).toHaveBeenCalledWith(
           customProps.studentEmail,
-          customProps.courseId,
+          customProps.classId,
         );
       });
     });

--- a/src/features/Main/DeleteEnrollment/index.jsx
+++ b/src/features/Main/DeleteEnrollment/index.jsx
@@ -24,9 +24,9 @@ import { deleteEnrollment } from 'features/Main/data/api';
  *
  * Props:
  * @param {string} studentEmail - The email of the student to unenroll.
- * @param {string} courseId - The ID of the course from which to unenroll the student.
+ * @param {string} classId - The ID of the class from which to unenroll the student.
  */
-const DeleteEnrollment = ({ studentEmail, courseId }) => {
+const DeleteEnrollment = ({ studentEmail, classId }) => {
   const [message, setMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const dispatch = useDispatch();
@@ -47,7 +47,7 @@ const DeleteEnrollment = ({ studentEmail, courseId }) => {
   const handleDeleteEnrollment = async () => {
     setIsSubmitting(true);
     try {
-      const response = await deleteEnrollment(studentEmail, courseId);
+      const response = await deleteEnrollment(studentEmail, classId);
       const result = response?.data?.results?.[0];
 
       if (result?.error) {
@@ -129,7 +129,7 @@ const DeleteEnrollment = ({ studentEmail, courseId }) => {
 
 DeleteEnrollment.propTypes = {
   studentEmail: PropTypes.string.isRequired,
-  courseId: PropTypes.string.isRequired,
+  classId: PropTypes.string.isRequired,
 };
 
 export default DeleteEnrollment;

--- a/src/features/Main/data/api.js
+++ b/src/features/Main/data/api.js
@@ -26,7 +26,7 @@ function assignStaffRole(classId) {
   );
 }
 
-function deleteEnrollment(studentEmail, courseId) {
+function deleteEnrollment(studentEmail, classId) {
   const BASE_URL = getConfig().LMS_BASE_URL;
 
   const formData = new FormData();
@@ -34,7 +34,7 @@ function deleteEnrollment(studentEmail, courseId) {
   formData.append('action', 'unenroll');
 
   return getAuthenticatedHttpClient().post(
-    `${BASE_URL}/courses/${courseId}/instructor/api/students_update_enrollment`,
+    `${BASE_URL}/courses/${classId}/instructor/api/students_update_enrollment`,
     formData,
   );
 }

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -95,7 +95,6 @@ const columns = [
       const {
         classId,
         userId,
-        courseId,
         learnerEmail,
       } = row.original;
 
@@ -124,7 +123,7 @@ const columns = [
             </Dropdown.Item>
             {
               row.values.status?.toLowerCase() !== 'expired' && (
-                <DeleteEnrollment studentEmail={learnerEmail} courseId={courseId} />
+                <DeleteEnrollment studentEmail={learnerEmail} classId={classId} />
               )
             }
           </Dropdown.Menu>


### PR DESCRIPTION
# Description
In this Pr is fixed the action "Delete enrollment" at the moment to perform the request the component was using the `courseId` instead of `classId`
- Updated unit test

## How to test
- Make sure to have this configured locally
- https://github.com/Pearson-Advance/course_operations/pull/380