### PR TITLE
PADV-2156 - auto-detect Superset session and skip /login redirect.

### DIFF
--- a/src/features/Classes/data/_test_/thunks.test.js
+++ b/src/features/Classes/data/_test_/thunks.test.js
@@ -11,31 +11,40 @@ jest.mock('rison-node', () => ({
 }));
 
 describe('supersetUrlClassesDashboard', () => {
+  const originalFetch = global.fetch;
+
   afterEach(() => {
     jest.clearAllMocks();
+    global.fetch = originalFetch;
   });
 
-  test('returns null when any required config value is missing', () => {
+  test('returns null when any required config value is missing', async () => {
     getConfig.mockReturnValue({
       SUPERSET_HOST: '',
       SUPERSET_DASHBOARD_SLUG: 'classes',
       SUPERSET_CLASS_FILTER_ID: 'filter_id',
     });
 
-    expect(supersetUrlClassesDashboard('abc123')).toBeNull();
+    const res = await supersetUrlClassesDashboard('abc123');
+    expect(res).toBeNull();
+    expect(global.fetch).toBeUndefined();
   });
 
-  test('builds the correct login URL when all config values are present', () => {
+  test('builds the correct login URL when the user has NO Superset session', async () => {
     getConfig.mockReturnValue({
       SUPERSET_HOST: 'https://superset.example.com',
       SUPERSET_DASHBOARD_SLUG: 'classes',
       SUPERSET_CLASS_FILTER_ID: 'filter_id',
     });
 
-    const classId = 'course-v1:Demo+Test+2025';
-    const url = supersetUrlClassesDashboard(classId);
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
 
-    const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}&standalone=true`;
+    const classId = 'course-v1:Demo+Test+2025';
+    const url = await supersetUrlClassesDashboard(classId);
+
+    const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}`
+      + '&standalone=true&expand_filters=0';
+
     const expected = `https://superset.example.com/login/?next=${encodeURIComponent(dashPath)}`;
 
     expect(url).toBe(expected);
@@ -46,6 +55,35 @@ describe('supersetUrlClassesDashboard', () => {
           filterState: { value: [classId], label: classId },
         }),
       }),
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://superset.example.com/api/v1/me/',
+      expect.any(Object),
+    );
+  });
+
+  test('returns the direct dashboard URL when the user already HAS a Superset session', async () => {
+    getConfig.mockReturnValue({
+      SUPERSET_HOST: 'https://superset.example.com',
+      SUPERSET_DASHBOARD_SLUG: 'classes',
+      SUPERSET_CLASS_FILTER_ID: 'filter_id',
+    });
+
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+
+    const classId = 'course-v1:Demo+Test+2025';
+    const url = await supersetUrlClassesDashboard(classId);
+
+    const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}`
+      + '&standalone=true&expand_filters=0';
+
+    const expected = `https://superset.example.com${dashPath}`;
+
+    expect(url).toBe(expected);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://superset.example.com/api/v1/me/',
+      expect.any(Object),
     );
   });
 });

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -108,7 +108,7 @@ function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
  * Builds a login URL that deep-links the user to the Superset “Classes”
  * dashboard, filtered to a single class.
 */
-function supersetUrlClassesDashboard(classId) {
+async function supersetUrlClassesDashboard(classId) {
   const {
     SUPERSET_HOST,
     SUPERSET_DASHBOARD_SLUG,
@@ -132,7 +132,23 @@ function supersetUrlClassesDashboard(classId) {
 
   const rison = risonEncode(nativeFilters);
   const dashboardPath = `/superset/dashboard/${SUPERSET_DASHBOARD_SLUG}/`
-    + `?native_filters=${encodeURIComponent(rison)}&standalone=true`;
+    + `?native_filters=${encodeURIComponent(rison)}&standalone=true&expand_filters=0`;
+
+  let hasSession = false;
+
+  try {
+    const resp = await fetch(`${SUPERSET_HOST}/api/v1/me/`, {
+      credentials: 'include',
+      mode: 'cors',
+    });
+    hasSession = resp.ok;
+  } catch {
+    hasSession = false;
+  }
+
+  if (hasSession) {
+    return `${SUPERSET_HOST}${dashboardPath}`;
+  }
 
   const loginUrl = new URL('/login/', SUPERSET_HOST);
   loginUrl.searchParams.set('next', dashboardPath);


### PR DESCRIPTION
## Description

- https://pearson.atlassian.net/browse/PADV-2156

## Description

This update refines the “Classes Insights (Beta)” action in the Classes table so that the resulting link is smart:

- If the browser already carries a valid Superset session cookie: The user is sent straight to the “Classes” dashboard (zero extra hops).
- If the session is missing or expired: The link falls back to /login/?next= and lands on the dashboard after sign-in.

The deep link still arrives pre-filtered to the selected class (course_key = <classId>) and is only rendered when all three Superset-related environment variables are present.

## Changes made

- [x] Refactor supersetUrlClassesDashboard()
- [x] Update unit tests

## How to test
- Set the site configurations
```
export SUPERSET_HOST=https://superset.local
export SUPERSET_DASHBOARD_SLUG=classes
export SUPERSET_CLASS_FILTER_ID=COURSE_KEY
```
- Re-build the MFE image and run tutor local launch.
- In one browser with a valid Superset cookie, open Classes → ⋯ → Classes Insights (Beta)
**Expected:** navigates directly to …/superset/dashboard/classes/….
- Open a private/incognito window (no Superset cookie) and repeat step 3.
Expected: hits …/login/?next=…, then lands on the dashboard after logging in.
- Run yarn test -t supersetUrlClassesDashboard — all specs should pass.

## Reviewers

- [ ] @AuraAlba