### PR TITLE
PADV-2156 - chore: handle async superset dashboard URL.

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -148,10 +148,10 @@ describe('columns', () => {
     expect(getByText('Lab Dashboard')).toBeInTheDocument();
   });
 
-  test('shows “Classes Insights (Beta)” when a dashboard URL is available', () => {
+  test('shows “Classes Insights (Beta)” when a dashboard URL is available', async () => {
     jest
       .spyOn(classesThunks, 'supersetUrlClassesDashboard')
-      .mockReturnValue('https://superset.example.com/dashboard/42');
+      .mockResolvedValue('https://superset.example.com/dashboard/42');
 
     const ActionColumn = () => columns[8].Cell({
       row: {
@@ -171,7 +171,7 @@ describe('columns', () => {
       },
     };
 
-    const { getByTestId, getByText } = renderWithProviders(
+    const { getByTestId, findByText } = renderWithProviders(
       <MemoryRouter initialEntries={['/classes/']}>
         <Route path="/classes/">
           <ActionColumn />
@@ -182,7 +182,8 @@ describe('columns', () => {
 
     fireEvent.click(getByTestId('droprown-action'));
 
-    expect(getByText('Classes Insights (Beta)')).toBeInTheDocument();
+    // wait for the effect to resolve the promise and re-render
+    expect(await findByText('Classes Insights (Beta)')).toBeInTheDocument();
 
     classesThunks.supersetUrlClassesDashboard.mockRestore();
   });

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -123,13 +123,26 @@ const columns = [
       const [isOpenModal, openModal, closeModal] = useToggle(false);
       const [deletionClassState, setDeletionState] = useState(initialDeletionClassState);
       const gradebookUrl = getConfig().GRADEBOOK_MICROFRONTEND_URL || getConfig().LMS_BASE_URL;
-      const classesDashboardUrl = supersetUrlClassesDashboard(classId);
       const {
         isVisible,
         message,
         showToast,
         hideToast,
       } = useToast();
+
+      const [classesDashboardUrl, setClassesDashboardUrl] = useState(null);
+
+      useEffect(() => {
+        let cancelled = false;
+        supersetUrlClassesDashboard(classId)
+          .then((url) => {
+            if (!cancelled) {
+              setClassesDashboardUrl(url);
+            }
+          })
+          .catch((err) => logError(err));
+        return () => { cancelled = true; };
+      }, [classId]);
 
       const handleResetDeletion = () => {
         setDeletionState(initialDeletionClassState);


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-2156

## Description

This PR handles the async superset URL construction made in https://github.com/Pearson-Advance/frontend-app-institution-portal/pull/189.

## Changes made

- [x] Use react tools to handle the async assignations
- [x] Update related tests

## How to test

- Set the site configurations
```
export SUPERSET_HOST=https://superset.local
export SUPERSET_DASHBOARD_SLUG=classes
export SUPERSET_CLASS_FILTER_ID=COURSE_KEY
```
- Re-build the MFE image and run tutor local launch.
- In one browser with a valid Superset cookie, open Classes → ⋯ → Classes Insights (Beta)
**Expected:** navigates directly to …/superset/dashboard/classes/….
- Open a private/incognito window (no Superset cookie) and repeat step 3.
Expected: hits …/login/?next=…, then lands on the dashboard after logging in.

## Reviewers

- [x] @AuraAlba 