### PR TITLE
PADV-2452 - feat: avoid login case and redirect to the superset URL directly.

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -151,7 +151,7 @@ describe('columns', () => {
   test('shows “Classes Insights (Beta)” when a dashboard URL is available', async () => {
     jest
       .spyOn(classesThunks, 'supersetUrlClassesDashboard')
-      .mockResolvedValue('https://superset.example.com/dashboard/42');
+      .mockReturnValue('https://superset.example.com/dashboard/42');
 
     const ActionColumn = () => columns[8].Cell({
       row: {
@@ -182,7 +182,6 @@ describe('columns', () => {
 
     fireEvent.click(getByTestId('droprown-action'));
 
-    // wait for the effect to resolve the promise and re-render
     expect(await findByText('Classes Insights (Beta)')).toBeInTheDocument();
 
     classesThunks.supersetUrlClassesDashboard.mockRestore();

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -130,19 +130,10 @@ const columns = [
         hideToast,
       } = useToast();
 
-      const [classesDashboardUrl, setClassesDashboardUrl] = useState(null);
-
-      useEffect(() => {
-        let cancelled = false;
-        supersetUrlClassesDashboard(classId)
-          .then((url) => {
-            if (!cancelled) {
-              setClassesDashboardUrl(url);
-            }
-          })
-          .catch((err) => logError(err));
-        return () => { cancelled = true; };
-      }, [classId]);
+      const classesDashboardUrl = useMemo(
+        () => supersetUrlClassesDashboard(classId),
+        [classId],
+      );
 
       const handleResetDeletion = () => {
         setDeletionState(initialDeletionClassState);

--- a/src/features/Classes/data/_test_/thunks.test.js
+++ b/src/features/Classes/data/_test_/thunks.test.js
@@ -25,12 +25,11 @@ describe('supersetUrlClassesDashboard', () => {
       SUPERSET_CLASS_FILTER_ID: 'filter_id',
     });
 
-    const res = await supersetUrlClassesDashboard('abc123');
+    const res = supersetUrlClassesDashboard('abc123');
     expect(res).toBeNull();
-    expect(global.fetch).toBeUndefined();
   });
 
-  test('builds the correct login URL when the user has NO Superset session', async () => {
+  test('builds the correct dashboard URL when config values are present', () => {
     getConfig.mockReturnValue({
       SUPERSET_HOST: 'https://superset.example.com',
       SUPERSET_DASHBOARD_SLUG: 'classes',
@@ -40,12 +39,12 @@ describe('supersetUrlClassesDashboard', () => {
     global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
 
     const classId = 'course-v1:Demo+Test+2025';
-    const url = await supersetUrlClassesDashboard(classId);
+    const url = supersetUrlClassesDashboard(classId);
 
     const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}`
-      + '&standalone=true&expand_filters=0';
+    + '&standalone=3&expand_filters=0';
 
-    const expected = `https://superset.example.com/login/?next=${encodeURIComponent(dashPath)}`;
+    const expected = `https://superset.example.com${dashPath}`;
 
     expect(url).toBe(expected);
 
@@ -55,35 +54,6 @@ describe('supersetUrlClassesDashboard', () => {
           filterState: { value: [classId], label: classId },
         }),
       }),
-    );
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://superset.example.com/api/v1/me/',
-      expect.any(Object),
-    );
-  });
-
-  test('returns the direct dashboard URL when the user already HAS a Superset session', async () => {
-    getConfig.mockReturnValue({
-      SUPERSET_HOST: 'https://superset.example.com',
-      SUPERSET_DASHBOARD_SLUG: 'classes',
-      SUPERSET_CLASS_FILTER_ID: 'filter_id',
-    });
-
-    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
-
-    const classId = 'course-v1:Demo+Test+2025';
-    const url = await supersetUrlClassesDashboard(classId);
-
-    const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}`
-      + '&standalone=true&expand_filters=0';
-
-    const expected = `https://superset.example.com${dashPath}`;
-
-    expect(url).toBe(expected);
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://superset.example.com/api/v1/me/',
-      expect.any(Object),
     );
   });
 });

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -105,10 +105,10 @@ function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
 }
 
 /**
- * Builds a login URL that deep-links the user to the Superset “Classes”
- * dashboard, filtered to a single class.
-*/
-async function supersetUrlClassesDashboard(classId) {
+ * Builds a URL that deep-links the user to the Superset “Classes”
+ * dashboard, filtered to a single class redirect.
+ */
+function supersetUrlClassesDashboard(classId) {
   const {
     SUPERSET_HOST,
     SUPERSET_DASHBOARD_SLUG,
@@ -131,29 +131,12 @@ async function supersetUrlClassesDashboard(classId) {
   };
 
   const rison = risonEncode(nativeFilters);
+
   const dashboardPath = `/superset/dashboard/${SUPERSET_DASHBOARD_SLUG}/`
-    + `?native_filters=${encodeURIComponent(rison)}&standalone=true&expand_filters=0`;
+    + `?native_filters=${encodeURIComponent(rison)}`
+    + '&standalone=3&expand_filters=0';
 
-  let hasSession = false;
-
-  try {
-    const resp = await fetch(`${SUPERSET_HOST}/api/v1/me/`, {
-      credentials: 'include',
-      mode: 'cors',
-    });
-    hasSession = resp.ok;
-  } catch {
-    hasSession = false;
-  }
-
-  if (hasSession) {
-    return `${SUPERSET_HOST}${dashboardPath}`;
-  }
-
-  const loginUrl = new URL('/login/', SUPERSET_HOST);
-  loginUrl.searchParams.set('next', dashboardPath);
-
-  return loginUrl.toString();
+  return new URL(dashboardPath, SUPERSET_HOST).toString();
 }
 
 export {


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-2452

## Description

This PR updates the Superset URL generation logic to bypass the login redirection and instead directly return the default dashboard URL, including parameters to hide filters and streamline the view.

## Changes made

- [x] Remove async integration
- [x] Update redirection URL 
- [x] Update related tests

## How to test

- Set the site configurations
```
export SUPERSET_HOST=https://superset.local
export SUPERSET_DASHBOARD_SLUG=classes
export SUPERSET_CLASS_FILTER_ID=COURSE_KEY
```
- Re-build the MFE image and run tutor local launch.
- In one browser with a valid Superset cookie, open Classes → ⋯ → Classes Insights (Beta)
**Expected:** navigates directly to …/superset/dashboard/classes/….
- Open a private/incognito window (no Superset cookie) and repeat step 3.
Expected: hits …/login/?next=…, then lands on the dashboard after logging in.

## Reviewers

- [x] @AuraAlba 