### PR TITLE
feat: instructor full name instead of user name

### DIFF
--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -44,10 +44,23 @@ const columns = [
     Header: 'Instructor',
     accessor: 'instructors',
     Cell: ({ row }) => {
+      const instructorInfo = useSelector((state) => state.instructors.selectOptions.data);
+
       if (row.values.instructors?.length > 0) {
         return (
           <ul className="instructors-list mb-0">
-            {row.values.instructors.map(instructor => <li key={instructor} className="text-truncate">{`${instructor}`}</li>)}
+
+            {row.values.instructors.map(instructorUsername => {
+              const instructorData = instructorInfo.find(
+                instructor => instructor.instructorUsername === instructorUsername,
+              );
+
+              return (
+                <li key={instructorUsername} className="text-truncate">
+                  {instructorData?.instructorName || instructorUsername}
+                </li>
+              );
+            })}
           </ul>
         );
       }

--- a/src/features/Courses/CourseDetailTable/columns.jsx
+++ b/src/features/Courses/CourseDetailTable/columns.jsx
@@ -51,10 +51,23 @@ const columns = [
     Header: 'Instructor',
     accessor: 'instructors',
     Cell: ({ row }) => {
+      const instructorInfo = useSelector((state) => state.instructors.selectOptions.data);
+
       if (row.values.instructors?.length > 0) {
         return (
           <ul className="instructors-list mb-0">
-            {row.values.instructors.map(instructor => <li key={instructor} className="text-truncate">{`${instructor}`}</li>)}
+
+            {row.values.instructors.map(instructorUsername => {
+              const instructorData = instructorInfo.find(
+                instructor => instructor.instructorUsername === instructorUsername,
+              );
+
+              return (
+                <li key={instructorUsername} className="text-truncate">
+                  {instructorData?.instructorName || instructorUsername}
+                </li>
+              );
+            })}
           </ul>
         );
       }

--- a/src/features/Courses/CoursesDetailPage/index.jsx
+++ b/src/features/Courses/CoursesDetailPage/index.jsx
@@ -12,6 +12,7 @@ import LinkWithQuery from 'features/Main/LinkWithQuery';
 import CourseDetailTable from 'features/Courses/CourseDetailTable';
 
 import { fetchClassesData } from 'features/Classes/data/thunks';
+import { fetchInstructorsOptionsData } from 'features/Instructors/data';
 import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 import { fetchClassesDataSuccess, updateCurrentPage as updateClassesCurrentPage } from 'features/Classes/data/slice';
 import { fetchCoursesDataSuccess, updateCurrentPage } from 'features/Courses/data/slice';
@@ -60,6 +61,7 @@ const CoursesDetailPage = () => {
 
     if (institution.id) {
       dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded));
+      dispatch(fetchInstructorsOptionsData(institution.id, initialPage, { limit: false }));
       dispatch(fetchCoursesOptionsData(institution.id));
     }
 


### PR DESCRIPTION
# Description
This PR improves the instructor display functionality by showing instructor names instead of usernames in the class list.

## Changes Made
- Modified the instructor mapping logic to match usernames with instructor data from Redux state.

## Visual changes
_Before_
<img width="1218" height="409" alt="before" src="https://github.com/user-attachments/assets/74e079b7-f1a6-4f0f-b5e2-42510d60e32a" />

_After_
<img width="1219" height="539" alt="after" src="https://github.com/user-attachments/assets/aaddbf0c-ef0a-4400-9c8c-835341cd5e4f" />


## Technical Details
- Added a `find()` operation to match `instructorUsername` from the Redux state with the usernames in `row.values.instructors`
- Implemented safe navigation (`?.`) to handle cases where instructor data might not be found
- Preserved the original username as a fallback to ensure the UI remains functional even with missing data


## Testing
- Go to `/classes` or `/courses/:courseId` to see the results
