### PR TITLE
fix: add word in enrollment info

### DIFF
--- a/src/features/Classes/InstructorCard/__test__/index.test.jsx
+++ b/src/features/Classes/InstructorCard/__test__/index.test.jsx
@@ -240,7 +240,7 @@ describe('InstructorCard', () => {
       },
     );
 
-    expect(container).toHaveTextContent('Enrollment:3 enrolled, 2 seats, 4 licenses');
+    expect(container).toHaveTextContent('Enrollment:3 enrolled, 2 seats available, 4 licenses');
   });
 
   test('Should render no max and 0 when null values are provided', () => {

--- a/src/features/Classes/InstructorCard/index.jsx
+++ b/src/features/Classes/InstructorCard/index.jsx
@@ -94,7 +94,7 @@ const InstructorCard = ({ previousPage }) => {
             </div>
             <div className="text-color">
               <b className="mr-1">Enrollment:</b>
-              {totalEnrolled} enrolled, {seatsAvailable} {seatsAvailable > 0 && 'seat'}{seatsAvailable > 1 && 's'}, {remainingLicenses} license{remainingLicenses > 1 && 's'} remaining
+              {totalEnrolled} enrolled, {seatsAvailable} {seatsAvailable > 0 && 'seat'}{seatsAvailable > 1 && 's'} {seatsAvailable > 0 && 'available'}, {remainingLicenses} license{remainingLicenses > 1 && 's'} remaining
             </div>
           </>
         )}


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1935

### Description
Add 'available' word to enrollment info

### Screenshoot
<img width="1448" height="322" alt="image" src="https://github.com/user-attachments/assets/c213be2f-a503-4fe4-9a2e-653762844467" />

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1980/
Go to a class detail

