### PR TITLE
PADV-2547 - feat: fetch and use user WaffleFlags for ClassesInsights access.

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -3,7 +3,6 @@ import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { columns } from 'features/Classes/ClassesTable/columns';
-
 import { renderWithProviders } from 'test-utils';
 
 import * as classesThunks from 'features/Classes/data/thunks';
@@ -19,6 +18,14 @@ describe('columns', () => {
     minStudents: 10,
     maxStudents: 100,
   };
+
+  beforeEach(() => {
+    jest.spyOn(classesThunks, 'supersetUrlClassesDashboard').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   test('returns an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
@@ -160,9 +167,9 @@ describe('columns', () => {
   });
 
   test('shows “Classes Insights (Beta)” when a dashboard URL is available', async () => {
-    jest
-      .spyOn(classesThunks, 'supersetUrlClassesDashboard')
-      .mockReturnValue('https://superset.example.com/dashboard/42');
+    classesThunks.supersetUrlClassesDashboard.mockResolvedValue(
+      'https://superset.example.com/dashboard/42',
+    );
 
     const ActionColumn = () => columns[8].Cell({
       row: {
@@ -197,7 +204,5 @@ describe('columns', () => {
     fireEvent.click(getByTestId('droprown-action'));
 
     expect(await findByText('Classes Insights (Beta)')).toBeInTheDocument();
-
-    classesThunks.supersetUrlClassesDashboard.mockRestore();
   });
 });

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useMemo, useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -145,11 +145,6 @@ const columns = [
         hideToast,
       } = useToast();
 
-      const classesDashboardUrl = useMemo(
-        () => supersetUrlClassesDashboard(classId),
-        [classId],
-      );
-
       const handleResetDeletion = () => {
         setDeletionState(initialDeletionClassState);
         dispatch(resetClassState());
@@ -182,6 +177,28 @@ const columns = [
           }));
         }
       };
+
+      const [classesDashboardUrl, setClassesDashboardUrl] = useState(null);
+
+      useEffect(() => {
+        let isMounted = true;
+
+        async function fetchSupersetDashboardUrl() {
+          const url = await supersetUrlClassesDashboard(
+            classId,
+            getConfig().CLASSES_INSIGHTS_FLAG,
+          );
+          if (isMounted) {
+            setClassesDashboardUrl(url);
+          }
+        }
+
+        fetchSupersetDashboardUrl();
+
+        return () => {
+          isMounted = false;
+        };
+      }, [classId]);
 
       const handleLabSummary = () => {
         dispatch(fetchLabSummaryLink(classId, labSummaryTag, (dashboardMessage) => {

--- a/src/features/Classes/data/_test_/thunks.test.js
+++ b/src/features/Classes/data/_test_/thunks.test.js
@@ -6,6 +6,12 @@ jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(),
 }));
 
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(() => ({
+    get: jest.fn(async () => ({ data: { enabled_flags: ['FLAG_NAME'] } })),
+  })),
+}));
+
 jest.mock('rison-node', () => ({
   encode: jest.fn(() => 'ENCODED'), // deterministic stub
 }));
@@ -25,11 +31,11 @@ describe('supersetUrlClassesDashboard', () => {
       SUPERSET_CLASS_FILTER_ID: 'filter_id',
     });
 
-    const res = supersetUrlClassesDashboard('abc123');
+    const res = await supersetUrlClassesDashboard('abc123', 'FLAG_NAME');
     expect(res).toBeNull();
   });
 
-  test('builds the correct dashboard URL when config values are present', () => {
+  test('builds the correct dashboard URL when config values are present', async () => {
     getConfig.mockReturnValue({
       SUPERSET_HOST: 'https://superset.example.com',
       SUPERSET_DASHBOARD_SLUG: 'classes',
@@ -39,10 +45,10 @@ describe('supersetUrlClassesDashboard', () => {
     global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
 
     const classId = 'course-v1:Demo+Test+2025';
-    const url = supersetUrlClassesDashboard(classId);
+    const url = await supersetUrlClassesDashboard(classId, 'FLAG_NAME');
 
     const dashPath = `/superset/dashboard/classes/?native_filters=${encodeURIComponent('ENCODED')}`
-    + '&standalone=3&expand_filters=0';
+      + '&standalone=3&expand_filters=0';
 
     const expected = `https://superset.example.com${dashPath}`;
 

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -13,7 +13,7 @@ import {
 } from 'features/Classes/data/slice';
 
 import { handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
-import { getClassesByInstitution } from 'features/Common/data/api';
+import { getClassesByInstitution, isFeatureEnabled } from 'features/Common/data/api';
 import { initialPage } from 'features/constants';
 import { encode as risonEncode } from 'rison-node';
 
@@ -105,10 +105,17 @@ function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
 }
 
 /**
- * Builds a URL that deep-links the user to the Superset “Classes”
- * dashboard, filtered to a single class redirect.
+ * Builds the Superset “Classes” dashboard URL if the feature is enabled.
+ *
+ * @param {string} classId
+ * @param {number|string} institutionId
+ * @param {string} flagName
+ * @returns {Promise<string|null>}
  */
-function supersetUrlClassesDashboard(classId) {
+async function supersetUrlClassesDashboard(classId, flagName) {
+  const isEnabled = await isFeatureEnabled({ flagName });
+  if (!isEnabled) { return null; }
+
   const {
     SUPERSET_HOST,
     SUPERSET_DASHBOARD_SLUG,


### PR DESCRIPTION
### Ticket

- https://pearson.atlassian.net/browse/PADV-2547

### Description

Gate the Classes Insights (Beta) deep-link behind a per-user feature flag and only surface it when we can confidently build a valid Superset URL. The URL is constructed with a native filter for the specific class and parameters to streamline the view (hide filters / standalone). If the flag is disabled or config is incomplete, the option is hidden.

### Changes made
- [x] Add isWaffleFlagScopedEnabled API helper to query the LMS (/pearson-core/feature_flags/scoped_status/).
- [x] Guard supersetUrlClassesDashboard(classId):
- [x] Returns null when the user-scoped flag is false or the check fails.
- [x] Show Classes Insights (Beta) only when a URL is available.
- [x] Update respective tests

### How to test
- Add the waffle flag `pearson_course_operation.waffle_flag_scoped_status` into the Django admin related with the following PR https://github.com/Pearson-Advance/pearson-core/pull/67.
- Add Users into the waffle flag verifying that the feature is enabled just for the user selected.
- Add the name of the flag in MFE_CONFIG in this case `"CLASSES_INSIGHTS_FLAG": "pearson_core.waffle_flag_classes_insights"`
```
export SUPERSET_HOST=https://superset.local
export SUPERSET_DASHBOARD_SLUG=classes
export SUPERSET_CLASS_FILTER_ID=COURSE_KEY
```
- Re-build the MFE image and run tutor local launch.
- In one browser with a valid Superset cookie, open Classes → ⋯ → Classes Insights (Beta)
**Expected:** navigates directly to …/superset/dashboard/classes/….
- Open a private/incognito window (no Superset cookie) and repeat step 3.
Expected: hits …/login/?next=…, then lands on the dashboard after logging in.

### Reviewers

- [x] @AuraAlba