### PR TITLE
refactor: show course title & reorder some columns

### DIFF
--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -33,11 +33,11 @@ describe('columns', () => {
 
     const [
       classNameColumn,
+      courseTitle,
       instructor,
-      enrollmentStatus,
       minStudentsAllowed,
-      studentsEnrolled,
       maxStudents,
+      studentsEnrolled,
       startDate,
       endDate,
     ] = columns;
@@ -51,8 +51,8 @@ describe('columns', () => {
     expect(minStudentsAllowed).toHaveProperty('Header', 'Min');
     expect(minStudentsAllowed).toHaveProperty('accessor', 'minStudentsAllowed');
 
-    expect(enrollmentStatus).toHaveProperty('Header', 'Enrollment status');
-    expect(enrollmentStatus).toHaveProperty('accessor', 'numberOfPendingStudents');
+    expect(courseTitle).toHaveProperty('Header', 'Course Title');
+    expect(courseTitle).toHaveProperty('accessor', 'masterCourseName');
 
     expect(studentsEnrolled).toHaveProperty('Header', 'Students Enrolled');
     expect(studentsEnrolled).toHaveProperty('accessor', 'numberOfStudents');

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -9,7 +9,6 @@ import {
   useToggle,
   Toast,
 } from '@edx/paragon';
-import { Badge } from 'react-paragon-topaz';
 import { MoreHoriz } from '@edx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
@@ -39,6 +38,15 @@ const columns = [
       >
         {row.values.className}
       </LinkWithQuery>
+    ),
+  },
+  {
+    Header: 'Course Title',
+    accessor: 'masterCourseName',
+    Cell: ({ row }) => (
+      <p className="text-truncate">
+        {row.original.masterCourseName}
+      </p>
     ),
   },
   {
@@ -74,29 +82,16 @@ const columns = [
     },
   },
   {
-    Header: 'Enrollment status',
-    accessor: 'numberOfPendingStudents',
-    Cell: ({ row }) => {
-      const isEnrollmentComplete = row.values.numberOfPendingStudents === 0;
-
-      return isEnrollmentComplete ? (
-        <Badge variant="success" light>Complete</Badge>
-      ) : (
-        <Badge variant="warning" light>Pending ({row.values.numberOfPendingStudents})</Badge>
-      );
-    },
-  },
-  {
     Header: 'Min',
     accessor: 'minStudentsAllowed',
   },
   {
-    Header: 'Students Enrolled',
-    accessor: 'numberOfStudents',
-  },
-  {
     Header: 'Max',
     accessor: 'maxStudents',
+  },
+  {
+    Header: 'Students Enrolled',
+    accessor: 'numberOfStudents',
   },
   {
     Header: 'Start Date',

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -44,9 +44,9 @@ const columns = [
     Header: 'Course Title',
     accessor: 'masterCourseName',
     Cell: ({ row }) => (
-      <p className="text-truncate">
+      <span className="text-truncate">
         {row.original.masterCourseName}
-      </p>
+      </span>
     ),
   },
   {


### PR DESCRIPTION
This pull request updates the `columns.jsx` file for the ClassesTable, making changes to the displayed columns and cleaning up unused imports. The most significant updates are the addition of a new "Course Title" column, reordering of columns, and removal of the "Enrollment status" column.

**Table column updates:**

* Added a "Course Title" column that displays the `masterCourseName` for each row.
* Removed the "Enrollment status" column, which previously showed whether enrollment was complete or pending.
* Moved the "Students Enrolled" column to appear after "Min" and before "Max" students columns, adjusting the order for better readability.

### How to test
1. Run a Pearson environment with Tutor or devstack
2. Clone this repo and switch to the branch of this PR
3. Start the institution-portal MFEs
4. Verify the table has the new required structure

    <img width="1861" height="1005" alt="image" src="https://github.com/user-attachments/assets/754eb8bf-bcd8-4118-b4d5-ff49adbc30cc" />

> [!NOTE]
> If the course title is too large, it should be shown truncated and with ellipses
>
> <img width="1380" height="323" alt="image" src="https://github.com/user-attachments/assets/c917693f-613a-4bed-b65b-91fba5811fbd" />


### Additional Information

- [Ticket 1918](https://pearson.atlassian.net/browse/PADV-1918?atlOrigin=eyJpIjoiZmM0Y2Q5Mjk0YWQ4NDZkNmE1ZDk1NGY0MGQ5ZmQzZjYiLCJwIjoiaiJ9)