### PR TITLE
PADV-3031: Replace voucher column 'N/A' value to 'Not assigned'

### DIFF
--- a/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
@@ -335,7 +335,7 @@ describe('Voucher Status column', () => {
     expect(getText(rendered)).toBe('revoked');
   });
 
-  test('displays "N/A" and "light" variant when voucherInfo is null', () => {
+  test('displays "not assigned" and "light" variant when voucherInfo is null', () => {
     const row = {
       values: {
         voucherInfo: null,
@@ -346,10 +346,10 @@ describe('Voucher Status column', () => {
     const rendered = Cell({ row });
 
     expect(rendered.props.variant).toBe('light');
-    expect(getText(rendered)).toBe('N/A');
+    expect(getText(rendered)).toBe('not assigned');
   });
 
-  test('displays "N/A" and "light" variant when voucherInfo has no computedStatus', () => {
+  test('displays "not assigned" and "light" variant when voucherInfo has no computedStatus', () => {
     const row = {
       values: {
         voucherInfo: {},
@@ -360,7 +360,7 @@ describe('Voucher Status column', () => {
     const rendered = Cell({ row });
 
     expect(rendered.props.variant).toBe('light');
-    expect(getText(rendered)).toBe('N/A');
+    expect(getText(rendered)).toBe('not assigned');
   });
 
   test('falls back to "light" variant when computedStatus does not match existing ones', () => {

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -71,7 +71,7 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
         light
         className="text-capitalize"
       >
-        {row.values?.voucherInfo?.computedStatus || 'N/A'}
+        {row.values?.voucherInfo?.computedStatus || 'not assigned'}
       </Badge>
     ),
   },

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -244,7 +244,7 @@ export const VOUCHER_RULE_TYPES = {
  * @enum {string}
  */
 export const VOUCHER_COMPUTED_STATUS = {
-  NOT_APPLICABLE: 'N/A',
+  NOT_ASSIGNED: 'not assigned',
   AVAILABLE: 'assigned',
   REVOKED: 'revoked',
 };
@@ -265,17 +265,17 @@ export const VOUCHER_BADGE_VARIANTS = {
  */
 export const VOUCHER_RULES = {
   [VOUCHER_RULE_TYPES.NO_VOUCHER]: {
-    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_APPLICABLE,
+    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_ASSIGNED,
     showAssign: true,
     showRevoke: false,
   },
   [VOUCHER_RULE_TYPES.OTHER_AVAILABLE]: {
-    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_APPLICABLE,
+    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_ASSIGNED,
     showAssign: false,
     showRevoke: false,
   },
   [VOUCHER_RULE_TYPES.OTHER_REVOKED]: {
-    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_APPLICABLE,
+    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_ASSIGNED,
     showAssign: true,
     showRevoke: false,
   },
@@ -290,7 +290,7 @@ export const VOUCHER_RULES = {
     showRevoke: false,
   },
   [VOUCHER_RULE_TYPES.DEFAULT]: {
-    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_APPLICABLE,
+    computedStatus: VOUCHER_COMPUTED_STATUS.NOT_ASSIGNED,
     showAssign: false,
     showRevoke: false,
   },


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-3031

### Description

This PR modifies the value on the voucher column of 'N/A' to 'Not assigned', this change was done to make the user more clear about the voucher status, not applicable didn't seem to align with what we wanted to let the user know about the voucher status.