### PR TITLE
PADV-2103: Show assign/revoke API error message on toast

### DIFF
--- a/src/features/Main/VoucherOptions/__test__/index.test.jsx
+++ b/src/features/Main/VoucherOptions/__test__/index.test.jsx
@@ -111,9 +111,25 @@ describe('VoucherOptions', () => {
     });
   });
 
-  test('should show error message when assignment fails', async () => {
+  test('should show custom error message from error.response.data.detail when assignment fails', async () => {
     getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
-    assignVoucher.mockRejectedValueOnce(new Error('Server error'));
+    const customErrorMessage = 'Custom error from API';
+    assignVoucher.mockRejectedValueOnce({ response: { data: { detail: customErrorMessage } } });
+
+    renderWithProviders(<VoucherOptions {...baseProps} />);
+
+    fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.ASSIGN));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(customErrorMessage),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('should show fallback error message when assignment fails and no detail is present', async () => {
+    getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
+    assignVoucher.mockRejectedValueOnce({});
 
     renderWithProviders(<VoucherOptions {...baseProps} />);
 
@@ -205,10 +221,25 @@ describe('VoucherOptions', () => {
     });
   });
 
-  test('should show default revoke error message for unexpected revoke errors', async () => {
+  test('should show custom error message from error.response.data.detail when revoke fails', async () => {
     getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
+    const customErrorMessage = 'Custom revoke error from API';
+    revokeVoucher.mockRejectedValueOnce({ response: { data: { detail: customErrorMessage } } });
 
-    revokeVoucher.mockRejectedValueOnce(new Error('Unknown error'));
+    renderWithProviders(<VoucherOptions {...baseProps} />);
+
+    fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.REVOKE));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(customErrorMessage),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('should show fallback revoke error message when revoke fails and no detail is present', async () => {
+    getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
+    revokeVoucher.mockRejectedValueOnce({});
 
     renderWithProviders(<VoucherOptions {...baseProps} />);
 

--- a/src/features/Main/VoucherOptions/index.jsx
+++ b/src/features/Main/VoucherOptions/index.jsx
@@ -78,8 +78,9 @@ const VoucherOptions = ({
       if (response?.status === HTTP_STATUS.CREATED) {
         showMessage(VOUCHER_SUCCESS_MESSAGES.ASSIGN);
       }
-    } catch {
-      showMessage(VOUCHER_ERROR_MESSAGES.ASSIGN);
+    } catch (error) {
+      const errorMessage = error?.response?.data?.detail || VOUCHER_ERROR_MESSAGES.ASSIGN;
+      showMessage(errorMessage);
     } finally {
       dispatch({ type: VOUCHER_ACTIONS.ASSIGN_END });
     }
@@ -111,7 +112,8 @@ const VoucherOptions = ({
         return;
       }
 
-      showMessage(VOUCHER_ERROR_MESSAGES.REVOKE);
+      const errorMessage = error?.response?.data?.detail || VOUCHER_ERROR_MESSAGES.REVOKE;
+      showMessage(errorMessage);
     } finally {
       dispatch({ type: VOUCHER_ACTIONS.REVOKE_END });
     }


### PR DESCRIPTION
### Ticket

https://pearson.atlassian.net/browse/PADV-2103

### Description

This PR modifies the assign/revoke voucher action to display the error message returned from the REST API response on the toast message instead of a generic unexpected error message. If the REST API fails to return any detail message the message uses the generic message has a fallback.