### PR TITLE
feat:Bulk Registration to use API for CSV uploads 

### DIFF
--- a/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
@@ -5,6 +5,7 @@ import {
   screen, fireEvent, act,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { getConfig } from '@edx/frontend-platform';
 
 import { renderWithProviders } from 'test-utils';
 import BulkRegister from 'features/BulkRegistration/BulkRegistrationPage';
@@ -36,6 +37,102 @@ jest.mock('@edx/paragon', () => {
   return { ...actual, DataTable: MockDataTable };
 });
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
+
+jest.mock('helpers', () => ({
+  validateCSVFile: jest.fn((file) => {
+    if (!file.name.endsWith('.csv')) {
+      return Promise.reject(new Error('Invalid file type'));
+    }
+    return Promise.resolve();
+  }),
+}));
+
+jest.mock('features/BulkRegistration/data/api', () => ({
+  postBulkRegister: jest.fn((file) => {
+    if (file.name === 'students.csv') {
+      return Promise.resolve({
+        data: {
+          errors: {
+            summary: {
+              total_rows: '8', created: '8', existed: '0', failed: '0',
+            },
+          },
+          rows: [],
+        },
+      });
+    }
+
+    if (file.name === 'partial.csv') {
+      return Promise.resolve({
+        data: {
+          errors: {
+            summary: {
+              total_rows: '8', created: '6', existed: '2', failed: '0',
+            },
+          },
+          rows: [],
+        },
+      });
+    }
+
+    if (file.name === 'error.csv') {
+      return Promise.resolve({
+        data: {
+          errors: {
+            summary: {
+              total_rows: '5', created: '2', existed: '0', failed: '3',
+            },
+          },
+          rows: [
+            {
+              row_number: '2',
+              email: 'a@example.com',
+              status: 'Validation failed',
+              errors: { email: ['Already exists'] },
+            },
+            {
+              row_number: '4',
+              email: 'b@example.com',
+              status: 'Validation failed',
+              errors: { first_name: ['This field is required'] },
+            },
+            {
+              row_number: '6',
+              email: 'c@example.com',
+              status: 'Processing failed',
+              errors: {},
+            },
+          ],
+        },
+      });
+    }
+
+    if (file.name === 'fatal.csv') {
+      const err = Object.assign(new Error('Server error'), {
+        response: {
+          status: 500,
+          data: { detail: 'Internal server error. Please contact support.' },
+        },
+      });
+      return Promise.reject(err);
+    }
+
+    return Promise.resolve({
+      data: {
+        errors: {
+          summary: {
+            total_rows: '0', created: '0', existed: '0', failed: '0',
+          },
+        },
+        rows: [],
+      },
+    });
+  }),
+}));
+
 const makeFile = (name, type = 'text/csv') => new File(['first_name,last_name\nJohn,Doe'], name, { type });
 
 let renderResult;
@@ -47,7 +144,15 @@ const renderComponent = () => {
         <BulkRegister />
       </Route>
     </MemoryRouter>,
-    { preloadedState: {} },
+    {
+      preloadedState: {
+        main: {
+          selectedInstitution: {
+            hasBulkRegister: true,
+          },
+        },
+      },
+    },
   );
   return renderResult;
 };
@@ -66,6 +171,7 @@ const selectFileAndSubmit = async (file) => {
 };
 
 beforeEach(() => {
+  getConfig.mockReturnValue({ PSS_ENABLE_BULK_REGISTRATION: true });
   jest.useFakeTimers();
   renderComponent();
 });
@@ -177,6 +283,7 @@ describe('Success', () => {
 
   test('Should display the correct numeric values in the partial success stat cards', async () => {
     await selectFileAndSubmit(makeFile('partial.csv'));
+    // total_rows=8, existed=2, created=6
     expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('6')).toBeInTheDocument();
@@ -192,7 +299,7 @@ describe('Error', () => {
   test('Should render the failed rows table with the correct column headers', async () => {
     await selectFileAndSubmit(makeFile('error.csv'));
     expect(screen.getAllByText(/failed rows/i).length).toBeGreaterThan(0);
-    ['ROW', 'FIRST NAME', 'LAST NAME', 'EMAIL', 'STATUS', 'MESSAGE'].forEach((header) => {
+    ['ROW', 'EMAIL', 'STATUS', 'MESSAGE'].forEach((header) => {
       expect(screen.getByText(header)).toBeInTheDocument();
     });
   });
@@ -245,5 +352,47 @@ describe('Navigation', () => {
   test('Should keep the Back to Students button visible on the fatal error screen', async () => {
     await selectFileAndSubmit(makeFile('fatal.csv'));
     expect(screen.getByRole('link', { name: /back to students/i })).toBeInTheDocument();
+  });
+});
+
+describe('Redirect', () => {
+  test('Should redirect to /students when hasBulkRegister is false', () => {
+    const { container } = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/bulk-registration']}>
+        <Route path="/students/bulk-registration">
+          <BulkRegister />
+        </Route>
+        <Route path="/students">
+          <div>Students page</div>
+        </Route>
+      </MemoryRouter>,
+      {
+        preloadedState: {
+          main: { selectedInstitution: { hasBulkRegister: false } },
+        },
+      },
+    );
+    expect(container).toHaveTextContent('Students page');
+  });
+
+  test('Should redirect to /students when PSS_ENABLE_BULK_REGISTRATION is false', () => {
+    getConfig.mockReturnValue({ PSS_ENABLE_BULK_REGISTRATION: false });
+
+    const { container } = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/bulk-registration']}>
+        <Route path="/students/bulk-registration">
+          <BulkRegister />
+        </Route>
+        <Route path="/students">
+          <div>Students page</div>
+        </Route>
+      </MemoryRouter>,
+      {
+        preloadedState: {
+          main: { selectedInstitution: { hasBulkRegister: true } },
+        },
+      },
+    );
+    expect(container).toHaveTextContent('Students page');
   });
 });

--- a/src/features/BulkRegistration/BulkRegistrationPage/columns.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/columns.jsx
@@ -2,8 +2,6 @@ import StatusBadge from 'features/BulkRegistration/BulkRegistrationPage/componen
 
 export const ERROR_COLUMNS = [
   { Header: 'ROW', accessor: 'row' },
-  { Header: 'FIRST NAME', accessor: 'firstName' },
-  { Header: 'LAST NAME', accessor: 'lastName' },
   { Header: 'EMAIL', accessor: 'email' },
   {
     Header: 'STATUS',

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/StatusBadge.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/StatusBadge.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 const StatusBadge = ({ status }) => {
   const map = {
-    'Validation failed': 'badge--error',
+    FAILED_VALIDATION: 'badge--error',
     'Processing failed': 'badge--warning',
   };
 

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessAll.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessAll.jsx
@@ -8,7 +8,7 @@ const SuccessAll = ({ data, onReset }) => (
       <div>
         <p className="success-banner__title">All registrations successful!</p>
         <p className="success-banner__subtitle">
-          We&apos;ve successfully registered all {data.totalRegistered} students from your uploaded file.
+          We&apos;ve successfully registered all {data.totalRegistered} {data.totalRegistered > 1 ? 'students' : 'student'} from your uploaded file.
         </p>
       </div>
     </div>

--- a/src/features/BulkRegistration/BulkRegistrationPage/index.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/index.jsx
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { Link, Redirect } from 'react-router-dom';
+import { getConfig } from '@edx/frontend-platform';
 
 import LoadingScreen from 'features/BulkRegistration/BulkRegistrationPage/components/LoadingScreen';
 import SuccessAll from 'features/BulkRegistration/BulkRegistrationPage/components/SuccessAll';
@@ -8,60 +10,21 @@ import ErrorRows from 'features/BulkRegistration/BulkRegistrationPage/components
 import FatalError from 'features/BulkRegistration/BulkRegistrationPage/components/FatalError';
 import UploadForm from 'features/BulkRegistration/BulkRegistrationPage/components/UploadForm';
 import { BULK_REGISTRATION_STATES } from 'features/constants';
+import { uploadCSV } from 'features/BulkRegistration/data';
 
 import './index.scss';
-
-// ─── Mock API call ────────────────────────────────────────────────────────────
-const mockUploadCSV = async (file) => {
-  await new Promise((resolve) => { setTimeout(resolve, 10); });
-
-  const name = file.name.toLowerCase();
-
-  if (name.includes('fatal') || name.includes('500')) {
-    throw Object.assign(new Error('Internal server error. Please contact support.'), { status: 500, detail: 'Internal server error. Please contact support.' });
-  }
-
-  if (name.includes('error') || name.includes('fail')) {
-    return {
-      type: BULK_REGISTRATION_STATES.ERROR_ROWS,
-      failedRows: [
-        {
-          row: 2, firstName: 'John', lastName: 'Smith', email: '-', status: 'Validation failed', message: 'Invalid or missing email address',
-        },
-        {
-          row: 5, firstName: 'Sarah', lastName: 'Williams', email: 'sarah.williams@example.com', status: 'Processing failed', message: 'Database connection timeout during account creation',
-        },
-        {
-          row: 7, firstName: '-', lastName: '-', email: 'incomplete@example.com', status: 'Validation failed', message: 'First name and last name are required',
-        },
-      ],
-    };
-  }
-
-  if (name.includes('partial') || name.includes('mixed')) {
-    return {
-      type: BULK_REGISTRATION_STATES.SUCCESS_PARTIAL,
-      totalRows: 8,
-      alreadyExisted: 2,
-      createdSuccessfully: 6,
-    };
-  }
-
-  return {
-    type: BULK_REGISTRATION_STATES.SUCCESS_ALL,
-    totalRegistered: 8,
-  };
-};
 
 const BulkRegister = () => {
   const [state, setState] = useState(BULK_REGISTRATION_STATES.IDLE);
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const enableBulkRegistration = getConfig()?.PSS_ENABLE_BULK_REGISTRATION || false;
+  const selectedInstitution = useSelector((store) => store.main.selectedInstitution);
 
   const handleUpload = useCallback(async (file) => {
     setState(BULK_REGISTRATION_STATES.LOADING);
     try {
-      const res = await mockUploadCSV(file);
+      const res = await uploadCSV(file);
       setResult(res);
       setState(res.type);
     } catch (err) {
@@ -75,6 +38,10 @@ const BulkRegister = () => {
     setResult(null);
     setError(null);
   }, []);
+
+  if (!selectedInstitution?.hasBulkRegister || !enableBulkRegistration) {
+    return <Redirect to="/students" />;
+  }
 
   return (
     <div className="bulk-register px-4 container-mw-xl container-fluid">

--- a/src/features/BulkRegistration/data/__test__/index.test.js
+++ b/src/features/BulkRegistration/data/__test__/index.test.js
@@ -1,0 +1,369 @@
+import { validateCSVFile } from 'helpers';
+import { uploadCSV } from 'features/BulkRegistration/data';
+import { postBulkRegister } from 'features/BulkRegistration/data/api';
+import { BULK_REGISTRATION_STATES } from 'features/constants';
+
+jest.mock('helpers', () => ({
+  validateCSVFile: jest.fn(),
+}));
+
+jest.mock('features/BulkRegistration/data/api', () => ({
+  postBulkRegister: jest.fn(),
+}));
+
+const makeFile = (name = 'students.csv') => new File([''], name, { type: 'text/csv' });
+
+const makeApiResponse = (summary = {}, rows = []) => ({
+  data: {
+    errors: {
+      summary: {
+        total_rows: '0', created: '0', existed: '0', failed: '0', ...summary,
+      },
+    },
+    rows,
+  },
+});
+
+const makeApiRow = (overrides = {}) => ({
+  row_number: '2',
+  email: 'user@example.com',
+  status: 'Validation failed',
+  errors: { email: ['This field is required'] },
+  ...overrides,
+});
+
+beforeEach(() => {
+  validateCSVFile.mockResolvedValue(undefined);
+  postBulkRegister.mockResolvedValue(makeApiResponse());
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('uploadCSV — happy path', () => {
+  test('Should call validateCSVFile with the provided file', async () => {
+    const file = makeFile();
+    await uploadCSV(file);
+    expect(validateCSVFile).toHaveBeenCalledWith(file);
+  });
+
+  test('Should call postBulkRegister with the provided file', async () => {
+    const file = makeFile();
+    await uploadCSV(file);
+    expect(postBulkRegister).toHaveBeenCalledWith(file);
+  });
+
+  test('Should return SUCCESS_ALL when there are no failures or existing users', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '5', created: '5', existed: '0', failed: '0',
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.type).toBe(BULK_REGISTRATION_STATES.SUCCESS_ALL);
+  });
+
+  test('Should return totalRegistered from created when SUCCESS_ALL', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '5', created: '5', existed: '0', failed: '0',
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.totalRegistered).toBe(5);
+  });
+
+  test('Should fall back to total_rows for totalRegistered when created is 0', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '3', created: '0', existed: '0', failed: '0',
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.totalRegistered).toBe(3);
+  });
+
+  test('Should return SUCCESS_PARTIAL when some users already existed', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '8', created: '6', existed: '2', failed: '0',
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.type).toBe(BULK_REGISTRATION_STATES.SUCCESS_PARTIAL);
+  });
+
+  test('Should return correct numeric stats for SUCCESS_PARTIAL', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '8', created: '6', existed: '2', failed: '0',
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.totalRows).toBe(8);
+    expect(result.createdSuccessfully).toBe(6);
+    expect(result.alreadyExisted).toBe(2);
+  });
+
+  test('Should return ERROR_ROWS when there are failed rows', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse(
+        {
+          total_rows: '3', created: '0', existed: '0', failed: '2',
+        },
+        [makeApiRow({ row_number: '2' }), makeApiRow({ row_number: '4' })],
+      ),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.type).toBe(BULK_REGISTRATION_STATES.ERROR_ROWS);
+  });
+
+  test('Should NOT return ERROR_ROWS when failed > 0 but rows array is empty', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse({
+        total_rows: '3', created: '3', existed: '0', failed: '1',
+      }, []),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    // No rows array → falls through to SUCCESS_ALL
+    expect(result.type).toBe(BULK_REGISTRATION_STATES.SUCCESS_ALL);
+  });
+});
+
+describe('uploadCSV — parseFailedRows', () => {
+  const rowsResponse = (rows) => makeApiResponse(
+    {
+      total_rows: String(rows.length), created: '0', existed: '0', failed: String(rows.length),
+    },
+    rows,
+  );
+
+  test('Should map row_number to row as (row_number - 1)', async () => {
+    postBulkRegister.mockResolvedValue(rowsResponse([makeApiRow({ row_number: '3' })]));
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].row).toBe(2);
+  });
+
+  test('Should include the email field from the API row', async () => {
+    postBulkRegister.mockResolvedValue(rowsResponse([makeApiRow({ email: 'test@test.com' })]));
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].email).toBe('test@test.com');
+  });
+
+  test('Should default email to "-" when it is missing', async () => {
+    postBulkRegister.mockResolvedValue(rowsResponse([makeApiRow({ email: undefined })]));
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].email).toBe('-');
+  });
+
+  test('Should include the status field from the API row', async () => {
+    postBulkRegister.mockResolvedValue(rowsResponse([makeApiRow({ status: 'Processing failed' })]));
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].status).toBe('Processing failed');
+  });
+
+  test('Should format message as "field: msg1, msg2" for a single error field', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: { email: ['Invalid format'] } })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].message).toBe('email: Invalid format');
+  });
+
+  test('Should join multiple messages for the same field with ", "', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: { email: ['Too short', 'Invalid format'] } })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].message).toBe('email: Too short, Invalid format');
+  });
+
+  test('Should join multiple error fields with " | "', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: { email: ['Required'], first_name: ['Too long'] } })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].message).toBe('email: Required | first_name: Too long');
+  });
+
+  test('Should produce an empty message string when errors object is empty', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: {} })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].message).toBe('');
+  });
+
+  test('Should produce an empty message string when errors field is missing', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: undefined })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows[0].message).toBe('');
+  });
+
+  test('Should map all rows in the response', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ row_number: '2' }), makeApiRow({ row_number: '5' })]),
+    );
+
+    const { failedRows } = await uploadCSV(makeFile());
+
+    expect(failedRows).toHaveLength(2);
+    expect(failedRows[0].row).toBe(1);
+    expect(failedRows[1].row).toBe(4);
+  });
+});
+
+describe('uploadCSV — validateCSVFile rejection', () => {
+  test('Should throw when validateCSVFile rejects', async () => {
+    validateCSVFile.mockRejectedValue(
+      Object.assign(new Error('Invalid file type'), { response: undefined }),
+    );
+
+    await expect(uploadCSV(makeFile('bad.xlsx'))).rejects.toThrow();
+  });
+
+  test('Should not call postBulkRegister when validateCSVFile rejects', async () => {
+    validateCSVFile.mockRejectedValue(
+      Object.assign(new Error('Invalid file type'), { response: undefined }),
+    );
+
+    try { await uploadCSV(makeFile('bad.xlsx')); } catch { /* expected */ }
+
+    expect(postBulkRegister).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadCSV — handleUploadError: 400 with csv_file array', () => {
+  const make400ArrayError = (messages) => Object.assign(new Error('Bad request'), {
+    response: { status: 400, data: { csv_file: messages } },
+  });
+
+  test('Should throw an error when 400 response has csv_file as an array', async () => {
+    postBulkRegister.mockRejectedValue(make400ArrayError(['File is empty.']));
+
+    await expect(uploadCSV(makeFile())).rejects.toThrow('File is empty.');
+  });
+
+  test('Should set error.status to 400', async () => {
+    postBulkRegister.mockRejectedValue(make400ArrayError(['File is empty.']));
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({ status: 400 });
+  });
+
+  test('Should set error.detail by joining the csv_file array messages', async () => {
+    postBulkRegister.mockRejectedValue(make400ArrayError(['Line 1 error.', 'Line 2 error.']));
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({
+      detail: 'Line 1 error. Line 2 error.',
+    });
+  });
+});
+
+describe('uploadCSV — handleUploadError: 400 with csv_file detail+rows', () => {
+  const make400RowsError = (csvError) => Object.assign(new Error('Bad request'), {
+    response: { status: 400, data: { csv_file: csvError } },
+  });
+
+  test('Should return ERROR_ROWS when 400 response has csv_file.detail and csv_file.rows', async () => {
+    postBulkRegister.mockRejectedValue(
+      make400RowsError({
+        detail: 'Some rows failed',
+        rows: [makeApiRow()],
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.type).toBe(BULK_REGISTRATION_STATES.ERROR_ROWS);
+  });
+
+  test('Should parse csv_file.rows into failedRows correctly', async () => {
+    postBulkRegister.mockRejectedValue(
+      make400RowsError({
+        detail: 'Some rows failed',
+        rows: [makeApiRow({ row_number: '3', email: 'x@x.com', status: 'Validation failed' })],
+      }),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.failedRows[0]).toMatchObject({ row: 2, email: 'x@x.com', status: 'Validation failed' });
+  });
+});
+
+describe('uploadCSV — handleUploadError: 500 / generic', () => {
+  const make500Error = (detail) => Object.assign(new Error('Server error'), {
+    response: { status: 500, data: { detail } },
+  });
+
+  test('Should throw when a 500 error is returned', async () => {
+    postBulkRegister.mockRejectedValue(make500Error('Internal server error. Please contact support.'));
+
+    await expect(uploadCSV(makeFile())).rejects.toThrow();
+  });
+
+  test('Should set error.status to the response status code', async () => {
+    postBulkRegister.mockRejectedValue(make500Error('Internal server error. Please contact support.'));
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({ status: 500 });
+  });
+
+  test('Should set error.detail from response.data.detail', async () => {
+    postBulkRegister.mockRejectedValue(make500Error('Internal server error. Please contact support.'));
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({
+      detail: 'Internal server error. Please contact support.',
+    });
+  });
+
+  test('Should fall back to generic message when response.data.detail is missing', async () => {
+    const err = Object.assign(new Error('Network failure'), { response: { status: 503, data: {} } });
+    postBulkRegister.mockRejectedValue(err);
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({
+      detail: 'Network failure',
+    });
+  });
+
+  test('Should use status 500 when error has no response object', async () => {
+    const err = Object.assign(new Error('No response'), { response: undefined });
+    validateCSVFile.mockRejectedValue(err);
+
+    await expect(uploadCSV(makeFile())).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/src/features/BulkRegistration/data/api.js
+++ b/src/features/BulkRegistration/data/api.js
@@ -1,0 +1,13 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform/config';
+
+export async function postBulkRegister(file) {
+  const apiV2BaseUrl = getConfig().COURSE_OPERATIONS_API_V2_BASE_URL;
+  const formData = new FormData();
+  formData.append('csv_file', file);
+
+  return getAuthenticatedHttpClient().post(
+    `${apiV2BaseUrl}/bulk-user-register/`,
+    formData,
+  );
+}

--- a/src/features/BulkRegistration/data/index.js
+++ b/src/features/BulkRegistration/data/index.js
@@ -1,0 +1,83 @@
+import { validateCSVFile } from 'helpers';
+import { BULK_REGISTRATION_STATES } from 'features/constants';
+import { postBulkRegister } from 'features/BulkRegistration/data/api';
+
+function parseFailedRows(rows) {
+  return rows.map((row) => ({
+    row: Number(row.row_number) - 1,
+    email: row.email || '-',
+    status: row.status,
+    message: Object.entries(row.errors || {})
+      .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
+      .join(' | '),
+  }));
+}
+
+function parseRegistrationResult(data) {
+  const summary = data?.errors?.summary ?? {};
+  const totalRows = Number(summary.total_rows || 0);
+  const created = Number(summary.created || 0);
+  const existed = Number(summary.existed || 0);
+  const failed = Number(summary.failed || 0);
+
+  if (failed > 0 && data.rows?.length) {
+    return {
+      type: BULK_REGISTRATION_STATES.ERROR_ROWS,
+      failedRows: parseFailedRows(data.rows),
+    };
+  }
+
+  if (existed > 0) {
+    return {
+      type: BULK_REGISTRATION_STATES.SUCCESS_PARTIAL,
+      totalRows,
+      alreadyExisted: existed,
+      createdSuccessfully: created,
+    };
+  }
+
+  return {
+    type: BULK_REGISTRATION_STATES.SUCCESS_ALL,
+    totalRegistered: created || totalRows,
+  };
+}
+
+function handleUploadError(error) {
+  const { response } = error;
+
+  if (response?.status === 400) {
+    const csvError = response.data?.csv_file;
+
+    if (Array.isArray(csvError)) {
+      throw Object.assign(new Error(csvError.join(' ')), {
+        status: 400,
+        detail: csvError.join(' '),
+      });
+    }
+
+    if (csvError?.detail && csvError?.rows) {
+      return {
+        type: BULK_REGISTRATION_STATES.ERROR_ROWS,
+        failedRows: parseFailedRows(csvError.rows),
+      };
+    }
+  }
+
+  throw Object.assign(
+    new Error(response?.data?.detail || 'Internal server error. Please contact support.'),
+    {
+      status: response?.status || 500,
+      detail: response?.data?.detail || error?.message,
+    },
+  );
+}
+
+export async function uploadCSV(file) {
+  try {
+    await validateCSVFile(file);
+    const { data } = await postBulkRegister(file);
+    return parseRegistrationResult(data);
+  } catch (error) {
+    return handleUploadError(error);
+  }
+}

--- a/src/features/Students/StudentsPage/index.jsx
+++ b/src/features/Students/StudentsPage/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { getConfig } from '@edx/frontend-platform';
 import { Pagination } from '@edx/paragon';
 import { Link } from 'react-router-dom';
 
@@ -15,6 +16,7 @@ import './index.scss';
 
 const StudentsPage = () => {
   const dispatch = useDispatch();
+  const enableBulkRegistration = getConfig()?.PSS_ENABLE_BULK_REGISTRATION || false;
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const stateStudents = useSelector((state) => state.students);
   const [currentPage, setCurrentPage] = useState(initialPage);
@@ -44,11 +46,15 @@ const StudentsPage = () => {
       <h2 className="title-page">Students</h2>
       <StudentsMetrics />
       <div className="page-content-container">
-        <div className="bulk-registration">
-          <Link to="/students/bulk-registration" className="bulk-registration__link">
-            Bulk registration
-          </Link>
-        </div>
+        {
+          (enableBulkRegistration && selectedInstitution?.hasBulkRegister) && (
+            <div className="bulk-registration">
+              <Link to="/students/bulk-registration" className="bulk-registration__link">
+                Bulk Registration
+              </Link>
+            </div>
+          )
+        }
         <StudentsFilters resetPagination={resetPagination} />
         <StudentsTable
           data={stateStudents.table.data}

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -310,3 +310,22 @@ export const BULK_REGISTRATION_STATES = {
   ERROR_ROWS: 'error_rows',
   ERROR_FATAL: 'error_fatal',
 };
+
+/**
+ * Required column names expected in the CSV header.
+ * These columns must exist in the first row of the uploaded CSV file
+ * for the validation to pass.
+ *
+ * @constant
+ * @type {string[]}
+ */
+export const BULK_REGISTRATION_REQUIRED_COLUMNS = ['First Name', 'Last Name', 'Email', 'Password'];
+
+/**
+ * Maximum number of data rows allowed in the CSV file (excluding the header).
+ * Used to prevent excessively large uploads.
+ *
+ * @constant
+ * @type {number}
+ */
+export const BULK_REGISTRATION_MAX_ROWS = 100;

--- a/src/helpers/__test__/index.test.js
+++ b/src/helpers/__test__/index.test.js
@@ -5,9 +5,11 @@ import {
   formatUTCDate,
   getInitials,
   setAssignStaffRole,
+  validateCSVFile,
 } from 'helpers';
 
 import { assignStaffRole } from 'features/Main/data/api';
+import { BULK_REGISTRATION_REQUIRED_COLUMNS, BULK_REGISTRATION_MAX_ROWS } from 'features/constants';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -118,5 +120,213 @@ describe('setAssignStaffRole', () => {
     expect(assignStaffRole).toHaveBeenCalledWith(classId);
     expect(logError).toHaveBeenCalledWith(error);
     expect(window.open).toHaveBeenCalledWith(url, '_blank', 'noopener,noreferrer');
+  });
+});
+
+describe('validateCSVFile', () => {
+  beforeAll(() => {
+    if (typeof File.prototype.text !== 'function') {
+      File.prototype.text = function text() {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result);
+          reader.onerror = () => reject(reader.error);
+          reader.readAsText(this);
+        });
+      };
+    }
+  });
+
+  afterAll(() => {
+    delete File.prototype.text;
+  });
+
+  const buildCSV = (rowCount = 1, headers = BULK_REGISTRATION_REQUIRED_COLUMNS) => {
+    const header = headers.join(',');
+    const rows = Array.from({ length: rowCount }, (_, i) => `John${i},Doe${i},John Doe ${i},john${i}@example.com,pass${i}`);
+    return [header, ...rows].join('\n');
+  };
+
+  const makeCSVFile = (content, name = 'students.csv', type = 'text/csv') => new File([content], name, { type });
+  const validFile = (rowCount = 1) => makeCSVFile(buildCSV(rowCount));
+
+  describe('file type', () => {
+    test('Should resolve true for a file with text/csv MIME type', async () => {
+      await expect(validateCSVFile(validFile())).resolves.toBe(true);
+    });
+
+    test('Should resolve true for a file with .csv extension regardless of MIME type', async () => {
+      const file = makeCSVFile(buildCSV(), 'data.csv', 'application/octet-stream');
+      await expect(validateCSVFile(file)).resolves.toBe(true);
+    });
+
+    test('Should resolve true for a file with uppercase .CSV extension', async () => {
+      const file = makeCSVFile(buildCSV(), 'DATA.CSV', 'application/octet-stream');
+      await expect(validateCSVFile(file)).resolves.toBe(true);
+    });
+
+    test('Should throw for a non-CSV MIME type without .csv extension', async () => {
+      const file = makeCSVFile('some content', 'students.xlsx', 'application/vnd.ms-excel');
+      await expect(validateCSVFile(file)).rejects.toThrow('Invalid file type. Only CSV files are allowed.');
+    });
+
+    test('Should set status 400 on the invalid file type error', async () => {
+      const file = makeCSVFile('content', 'data.pdf', 'application/pdf');
+      await expect(validateCSVFile(file)).rejects.toMatchObject({ status: 400 });
+    });
+
+    test('Should set detail on the invalid file type error', async () => {
+      const file = makeCSVFile('content', 'data.pdf', 'application/pdf');
+      await expect(validateCSVFile(file)).rejects.toMatchObject({
+        detail: 'Invalid file type. Only CSV files are allowed.',
+      });
+    });
+  });
+
+  describe('empty file', () => {
+    test('Should throw for a completely empty file', async () => {
+      const file = makeCSVFile('');
+      await expect(validateCSVFile(file)).rejects.toThrow('The CSV file is empty.');
+    });
+
+    test('Should throw for a file containing only whitespace', async () => {
+      const file = makeCSVFile('   \n   \n   ');
+      await expect(validateCSVFile(file)).rejects.toThrow('The CSV file is empty.');
+    });
+
+    test('Should set status 400 on the empty file error', async () => {
+      await expect(validateCSVFile(makeCSVFile(''))).rejects.toMatchObject({ status: 400 });
+    });
+
+    test('Should set detail on the empty file error', async () => {
+      await expect(validateCSVFile(makeCSVFile(''))).rejects.toMatchObject({
+        detail: 'The CSV file is empty.',
+      });
+    });
+  });
+
+  describe('missing required columns', () => {
+    test('Should throw when all required columns are missing', async () => {
+      const file = makeCSVFile('foo,bar\nval1,val2');
+      await expect(validateCSVFile(file)).rejects.toThrow('Missing required columns:');
+    });
+
+    test('Should include the missing column names in the error message', async () => {
+      const headers = [...BULK_REGISTRATION_REQUIRED_COLUMNS];
+      headers.splice(0, 2);
+      const content = [headers.join(','), 'John Doe,john@example.com,pass'].join('\n');
+      const file = makeCSVFile(content);
+      await expect(validateCSVFile(file)).rejects.toThrow('Missing required columns: First Name, Last Name');
+    });
+
+    test('Should throw when only one required column is missing', async () => {
+      const headers = BULK_REGISTRATION_REQUIRED_COLUMNS.filter((c) => c !== 'email');
+      const content = [headers.join(','), 'John,Doe,John Doe,pass'].join('\n');
+      await expect(validateCSVFile(makeCSVFile(content))).toBeTruthy();
+    });
+
+    test('Should set status 400 on the missing columns error', async () => {
+      const file = makeCSVFile('foo,bar\nval1,val2');
+      await expect(validateCSVFile(file)).rejects.toMatchObject({ status: 400 });
+    });
+
+    test('Should set detail matching the error message on missing columns', async () => {
+      const file = makeCSVFile('foo,bar\nval1,val2');
+      await expect(validateCSVFile(file)).rejects.toMatchObject({
+        detail: expect.stringContaining('Missing required columns:'),
+      });
+    });
+
+    test('Should strip surrounding quotes from header values before checking', async () => {
+      const quotedHeader = BULK_REGISTRATION_REQUIRED_COLUMNS.map((c) => `"${c}"`).join(',');
+      const content = [quotedHeader, 'John,Doe,John Doe,john@example.com,pass'].join('\n');
+      await expect(validateCSVFile(makeCSVFile(content))).resolves.toBe(true);
+    });
+
+    test('Should trim whitespace from header values before checking', async () => {
+      const spacedHeader = BULK_REGISTRATION_REQUIRED_COLUMNS.map((c) => `  ${c}  `).join(',');
+      const content = [spacedHeader, 'John,Doe,John Doe,john@example.com,pass'].join('\n');
+      await expect(validateCSVFile(makeCSVFile(content))).resolves.toBe(true);
+    });
+
+    test('Should not throw when extra columns beyond required are present', async () => {
+      const headers = [...BULK_REGISTRATION_REQUIRED_COLUMNS, 'phone', 'country'];
+      const content = [headers.join(','), 'John,Doe,John Doe,john@example.com,pass,555,US'].join('\n');
+      await expect(validateCSVFile(makeCSVFile(content))).resolves.toBe(true);
+    });
+  });
+
+  describe('no data rows', () => {
+    test('Should throw when the file contains only the header row', async () => {
+      const file = makeCSVFile(BULK_REGISTRATION_REQUIRED_COLUMNS.join(','));
+      await expect(validateCSVFile(file)).rejects.toThrow('The CSV file must contain at least 1 data row.');
+    });
+
+    test('Should throw when the only non-empty content is the header', async () => {
+      const content = `${BULK_REGISTRATION_REQUIRED_COLUMNS.join(',')}\n   \n   `;
+      await expect(validateCSVFile(makeCSVFile(content))).rejects.toThrow(
+        'The CSV file must contain at least 1 data row.',
+      );
+    });
+
+    test('Should set status 400 on the no data rows error', async () => {
+      const file = makeCSVFile(BULK_REGISTRATION_REQUIRED_COLUMNS.join(','));
+      await expect(validateCSVFile(file)).rejects.toMatchObject({ status: 400 });
+    });
+
+    test('Should set detail on the no data rows error', async () => {
+      const file = makeCSVFile(BULK_REGISTRATION_REQUIRED_COLUMNS.join(','));
+      await expect(validateCSVFile(file)).rejects.toMatchObject({
+        detail: 'The CSV file must contain at least 1 data row.',
+      });
+    });
+  });
+
+  describe('max rows exceeded', () => {
+    test(`Should throw when the file has more than ${BULK_REGISTRATION_MAX_ROWS} data rows`, async () => {
+      const file = validFile(BULK_REGISTRATION_MAX_ROWS + 1);
+      await expect(validateCSVFile(file)).rejects.toThrow('exceeds the maximum allowed rows');
+    });
+
+    test('Should include the max and actual count in the error message', async () => {
+      const overLimit = BULK_REGISTRATION_MAX_ROWS + 5;
+      const file = validFile(overLimit);
+      await expect(validateCSVFile(file)).rejects.toThrow(`Max: ${BULK_REGISTRATION_MAX_ROWS}, Found: ${overLimit}`);
+    });
+
+    test('Should set status 400 on the max rows exceeded error', async () => {
+      await expect(validateCSVFile(validFile(BULK_REGISTRATION_MAX_ROWS + 1))).rejects.toMatchObject({ status: 400 });
+    });
+
+    test('Should set detail matching the error message on max rows exceeded', async () => {
+      await expect(validateCSVFile(validFile(BULK_REGISTRATION_MAX_ROWS + 1))).rejects.toMatchObject({
+        detail: expect.stringContaining('exceeds the maximum allowed rows'),
+      });
+    });
+
+    test(`Should resolve true for a file with exactly ${BULK_REGISTRATION_MAX_ROWS} data rows`, async () => {
+      await expect(validateCSVFile(validFile(BULK_REGISTRATION_MAX_ROWS))).resolves.toBe(true);
+    });
+
+    test('Should resolve true for a file with 1 data row', async () => {
+      await expect(validateCSVFile(validFile(1))).resolves.toBe(true);
+    });
+  });
+
+  describe('validation priority order', () => {
+    test('Should throw file type error before checking for empty content', async () => {
+      const file = makeCSVFile('', 'data.pdf', 'application/pdf');
+      await expect(validateCSVFile(file)).rejects.toThrow('Invalid file type');
+    });
+
+    test('Should throw empty file error before checking required columns', async () => {
+      const file = makeCSVFile('\n\n');
+      await expect(validateCSVFile(file)).rejects.toThrow('The CSV file is empty.');
+    });
+
+    test('Should throw missing columns error before checking data rows', async () => {
+      const file = makeCSVFile('foo,bar');
+      await expect(validateCSVFile(file)).rejects.toThrow('Missing required columns:');
+    });
   });
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { assignStaffRole } from 'features/Main/data/api';
+import { BULK_REGISTRATION_MAX_ROWS, BULK_REGISTRATION_REQUIRED_COLUMNS } from 'features/constants';
 
 /**
  * Format a UTC date
@@ -153,3 +154,88 @@ export const formatSelectOptions = (options) => {
     value: option.id,
   }));
 };
+
+/**
+ * Validates a CSV file before processing.
+ *
+ * The function performs several checks:
+ * - Ensures the file is a CSV based on MIME type or file extension.
+ * - Verifies the file is not empty.
+ * - Confirms that all required columns are present in the header row.
+ * - Ensures the file contains at least one data row.
+ * - Enforces a maximum number of allowed rows.
+ *
+ * If any validation fails, an Error is thrown with additional metadata
+ * (`status` and `detail`) that can be used for API responses.
+ *
+ * @async
+ * @function validateCSVFile
+ * @param {File} file - The uploaded file object to validate.
+ *
+ * @throws {Error} Throws an error if:
+ * - The file is not a CSV.
+ * - The file is empty.
+ * - Required columns are missing.
+ * - The file has no data rows.
+ * - The file exceeds the maximum allowed number of rows.
+ *
+ * @returns {Promise<boolean>} Resolves to `true` if the file passes all validations.
+ */
+export async function validateCSVFile(file) {
+  const isCSV = file.type === 'text/csv'
+    || file.name.toLowerCase().endsWith('.csv');
+
+  if (!isCSV) {
+    throw Object.assign(new Error('Invalid file type. Only CSV files are allowed.'), {
+      status: 400,
+      detail: 'Invalid file type. Only CSV files are allowed.',
+    });
+  }
+
+  const text = await file.text();
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    throw Object.assign(new Error('The CSV file is empty.'), {
+      status: 400,
+      detail: 'The CSV file is empty.',
+    });
+  }
+
+  const headers = lines[0].split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
+  const missingColumns = BULK_REGISTRATION_REQUIRED_COLUMNS.filter((col) => !headers.includes(col));
+
+  if (missingColumns.length > 0) {
+    throw Object.assign(
+      new Error(`Missing required columns: ${missingColumns.join(', ')}`),
+      {
+        status: 400,
+        detail: `Missing required columns: ${missingColumns.join(', ')}`,
+      },
+    );
+  }
+
+  const dataRows = lines.length - 1;
+
+  if (dataRows <= 0) {
+    throw Object.assign(new Error('The CSV file must contain at least 1 data row.'), {
+      status: 400,
+      detail: 'The CSV file must contain at least 1 data row.',
+    });
+  }
+
+  if (dataRows > BULK_REGISTRATION_MAX_ROWS) {
+    throw Object.assign(
+      new Error(`The CSV file exceeds the maximum allowed rows. Max: ${BULK_REGISTRATION_MAX_ROWS}, Found: ${dataRows}`),
+      {
+        status: 400,
+        detail: `The CSV file exceeds the maximum allowed rows. Max: ${BULK_REGISTRATION_MAX_ROWS}, Found: ${dataRows}`,
+      },
+    );
+  }
+
+  return true;
+}


### PR DESCRIPTION
# Description
This PR removes the dummy implementation previously used for uploading CSV files and connects the feature to the backend so it works with the real API.

A small client-side validation was added before sending the file to ensure the format is correct and prevent unnecessary requests. Additionally, basic error handling was implemented to properly surface potential backend or validation errors to the user.

## Ticket
https://pearson.atlassian.net/browse/PADV-3183

## How to test
- Enable `PSS_ENABLE_BULK_REGISTRATION` in your site configs
- Make sure the institution that you are testing has `"has_bulk_register": true`