### PR TITLE
fix: improve error handling in parseFailedRows

### DIFF
--- a/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
@@ -59,8 +59,8 @@ jest.mock('features/BulkRegistration/data/api', () => ({
             summary: {
               total_rows: '8', created: '8', existed: '0', failed: '0',
             },
+            rows: [],
           },
-          rows: [],
         },
       });
     }
@@ -72,8 +72,8 @@ jest.mock('features/BulkRegistration/data/api', () => ({
             summary: {
               total_rows: '8', created: '6', existed: '2', failed: '0',
             },
+            rows: [],
           },
-          rows: [],
         },
       });
     }
@@ -85,27 +85,27 @@ jest.mock('features/BulkRegistration/data/api', () => ({
             summary: {
               total_rows: '5', created: '2', existed: '0', failed: '3',
             },
+            rows: [
+              {
+                row_number: '2',
+                email: 'a@example.com',
+                status: 'Validation failed',
+                errors: { email: ['Already exists'] },
+              },
+              {
+                row_number: '4',
+                email: 'b@example.com',
+                status: 'Validation failed',
+                errors: { first_name: ['This field is required'] },
+              },
+              {
+                row_number: '6',
+                email: 'c@example.com',
+                status: 'Processing failed',
+                errors: {},
+              },
+            ],
           },
-          rows: [
-            {
-              row_number: '2',
-              email: 'a@example.com',
-              status: 'Validation failed',
-              errors: { email: ['Already exists'] },
-            },
-            {
-              row_number: '4',
-              email: 'b@example.com',
-              status: 'Validation failed',
-              errors: { first_name: ['This field is required'] },
-            },
-            {
-              row_number: '6',
-              email: 'c@example.com',
-              status: 'Processing failed',
-              errors: {},
-            },
-          ],
         },
       });
     }
@@ -126,8 +126,8 @@ jest.mock('features/BulkRegistration/data/api', () => ({
           summary: {
             total_rows: '0', created: '0', existed: '0', failed: '0',
           },
+          rows: [],
         },
-        rows: [],
       },
     });
   }),

--- a/src/features/BulkRegistration/data/__test__/index.test.js
+++ b/src/features/BulkRegistration/data/__test__/index.test.js
@@ -19,8 +19,8 @@ const makeApiResponse = (summary = {}, rows = []) => ({
       summary: {
         total_rows: '0', created: '0', existed: '0', failed: '0', ...summary,
       },
+      rows,
     },
-    rows,
   },
 });
 
@@ -133,9 +133,12 @@ describe('uploadCSV — happy path', () => {
 
   test('Should NOT return ERROR_ROWS when failed > 0 but rows array is empty', async () => {
     postBulkRegister.mockResolvedValue(
-      makeApiResponse({
-        total_rows: '3', created: '3', existed: '0', failed: '1',
-      }, []),
+      makeApiResponse(
+        {
+          total_rows: '3', created: '3', existed: '0', failed: '1',
+        },
+        [],
+      ),
     );
 
     const result = await uploadCSV(makeFile());
@@ -145,10 +148,13 @@ describe('uploadCSV — happy path', () => {
   });
 });
 
-describe('uploadCSV — parseFailedRows', () => {
+describe('uploadCSV — parseFailedRows with object errors', () => {
   const rowsResponse = (rows) => makeApiResponse(
     {
-      total_rows: String(rows.length), created: '0', existed: '0', failed: String(rows.length),
+      total_rows: String(rows.length),
+      created: '0',
+      existed: '0',
+      failed: String(rows.length),
     },
     rows,
   );
@@ -185,7 +191,7 @@ describe('uploadCSV — parseFailedRows', () => {
     expect(failedRows[0].status).toBe('Processing failed');
   });
 
-  test('Should format message as "field: msg1, msg2" for a single error field', async () => {
+  test('Should format message as "field: msg" for a single error field', async () => {
     postBulkRegister.mockResolvedValue(
       rowsResponse([makeApiRow({ errors: { email: ['Invalid format'] } })]),
     );
@@ -215,24 +221,13 @@ describe('uploadCSV — parseFailedRows', () => {
     expect(failedRows[0].message).toBe('email: Required | first_name: Too long');
   });
 
-  test('Should produce an empty message string when errors object is empty', async () => {
-    postBulkRegister.mockResolvedValue(
-      rowsResponse([makeApiRow({ errors: {} })]),
-    );
-
-    const { failedRows } = await uploadCSV(makeFile());
-
-    expect(failedRows[0].message).toBe('');
-  });
-
-  test('Should produce an empty message string when errors field is missing', async () => {
+  test('Should produce "-" as message when errors field is missing', async () => {
     postBulkRegister.mockResolvedValue(
       rowsResponse([makeApiRow({ errors: undefined })]),
     );
 
     const { failedRows } = await uploadCSV(makeFile());
-
-    expect(failedRows[0].message).toBe('');
+    expect(failedRows[0].message).toBe('-');
   });
 
   test('Should map all rows in the response', async () => {
@@ -245,6 +240,34 @@ describe('uploadCSV — parseFailedRows', () => {
     expect(failedRows).toHaveLength(2);
     expect(failedRows[0].row).toBe(1);
     expect(failedRows[1].row).toBe(4);
+  });
+});
+
+describe('uploadCSV — parseFailedRows with array errors', () => {
+  const rowsResponse = (rows) => makeApiResponse(
+    {
+      total_rows: String(rows.length),
+      created: '0',
+      existed: '0',
+      failed: String(rows.length),
+    },
+    rows,
+  );
+
+  test('Should join array errors into a single comma-separated message', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: ['Invalid email', 'Name required'] })]),
+    );
+    const { failedRows } = await uploadCSV(makeFile());
+    expect(failedRows[0].message).toBe('Invalid email, Name required');
+  });
+
+  test('Should use a single array error message as-is', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: ['Row is malformed'] })]),
+    );
+    const { failedRows } = await uploadCSV(makeFile());
+    expect(failedRows[0].message).toBe('Row is malformed');
   });
 });
 
@@ -301,10 +324,7 @@ describe('uploadCSV — handleUploadError: 400 with csv_file detail+rows', () =>
 
   test('Should return ERROR_ROWS when 400 response has csv_file.detail and csv_file.rows', async () => {
     postBulkRegister.mockRejectedValue(
-      make400RowsError({
-        detail: 'Some rows failed',
-        rows: [makeApiRow()],
-      }),
+      make400RowsError({ detail: 'Some rows failed', rows: [makeApiRow()] }),
     );
 
     const result = await uploadCSV(makeFile());
@@ -351,7 +371,7 @@ describe('uploadCSV — handleUploadError: 500 / generic', () => {
     });
   });
 
-  test('Should fall back to generic message when response.data.detail is missing', async () => {
+  test('Should fall back to error.message when response.data.detail is missing', async () => {
     const err = Object.assign(new Error('Network failure'), { response: { status: 503, data: {} } });
     postBulkRegister.mockRejectedValue(err);
 

--- a/src/features/BulkRegistration/data/index.js
+++ b/src/features/BulkRegistration/data/index.js
@@ -3,14 +3,24 @@ import { BULK_REGISTRATION_STATES } from 'features/constants';
 import { postBulkRegister } from 'features/BulkRegistration/data/api';
 
 function parseFailedRows(rows) {
-  return rows.map((row) => ({
-    row: Number(row.row_number) - 1,
-    email: row.email || '-',
-    status: row.status,
-    message: Object.entries(row.errors || {})
-      .map(([field, msgs]) => `${field}: ${msgs.join(', ')}`)
-      .join(' | '),
-  }));
+  return rows.map((row) => {
+    let message = '-';
+
+    if (Array.isArray(row.errors)) {
+      message = row.errors.length ? row.errors.join(', ') : '-';
+    } else if (row.errors && typeof row.errors === 'object') {
+      message = Object.entries(row.errors)
+        .map(([field, msgs]) => `${field}: ${msgs?.join(', ')}`)
+        .join(' | ');
+    }
+
+    return {
+      row: Number(row.row_number) - 1,
+      email: row.email || '-',
+      status: row.status,
+      message,
+    };
+  });
 }
 
 function parseRegistrationResult(data) {
@@ -20,10 +30,10 @@ function parseRegistrationResult(data) {
   const existed = Number(summary.existed || 0);
   const failed = Number(summary.failed || 0);
 
-  if (failed > 0 && data.rows?.length) {
+  if (failed > 0 && data?.errors.rows?.length) {
     return {
       type: BULK_REGISTRATION_STATES.ERROR_ROWS,
-      failedRows: parseFailedRows(data.rows),
+      failedRows: parseFailedRows(data.errors.rows),
     };
   }
 


### PR DESCRIPTION
# Description

This PR addresses an edge case in bulk registration error handling to improve reliability and feedback.

## How to test

- Go to `/bulk-registration`
- Upload a file
- Override `/bulk-user-register/` with

```javascript
{
    "uuid": "ab188d56-95f1-43fb-83b2-bd4b8302d60c",
    "status": "DONE",
    "errors": {
        "summary": {
            "total_rows": 1,
            "created": 0,
            "existed": 0,
            "failed": 1
        },
        "rows": [
            {
                "row_number": 2,
                "email": "dada.doe.1234@ciwt.com",
                "status": "FAILED_CREATE",
                "errors": [
                    "Unexpected error: Error querying users: Invalid URL '/openidm/endpoint/queryidentity': No scheme supplied. Perhaps you meant http:///openidm/endpoint/queryidentity?"
                ]
            }
        ]
    }
}
``` 

You should be able to see the table with the result