### PR TITLE
PADV-3218 - Modify Upload another button name.

### DIFF
--- a/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
@@ -315,9 +315,9 @@ describe('Error', () => {
     expect(screen.getByText('Processing failed')).toBeInTheDocument();
   });
 
-  test('Should return to the idle upload form after clicking Upload Another', async () => {
+  test('Should return to the idle upload form after clicking Upload a new file', async () => {
     await selectFileAndSubmit(makeFile('error.csv'));
-    fireEvent.click(screen.getByRole('button', { name: /upload another/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload a new file/i }));
     expect(screen.getByRole('button', { name: /upload & process/i })).toBeInTheDocument();
   });
 

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/ErrorRows.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/ErrorRows.jsx
@@ -20,7 +20,7 @@ const ErrorRows = ({ data, onReset }) => (
       </span>
       <Button type="button" className="btn btn--outline btn--sm" onClick={onReset}>
         <i className="fa-sharp fa-thin fa-file-spreadsheet" />
-        Upload Another
+        Upload a new file
       </Button>
     </div>
 

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessAll.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessAll.jsx
@@ -15,7 +15,7 @@ const SuccessAll = ({ data, onReset }) => (
     <div className="state-actions">
       <Button type="button" className="btn btn--outline" onClick={onReset}>
         <i className="fa-sharp fa-thin fa-file-spreadsheet" />
-        Upload another file
+        Upload a new file
       </Button>
     </div>
   </div>

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessPartial.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessPartial.jsx
@@ -20,6 +20,7 @@ const SuccessPartial = ({ data, onReset }) => (
     </div>
     <div className="state-actions">
       <Button type="button" className="btn btn--outline" onClick={onReset}>
+        <i className="fa-sharp fa-thin fa-file-spreadsheet" />
         Upload a new file
       </Button>
     </div>


### PR DESCRIPTION
# Description

In this PR is updated the button text from `Upload another` to `Upload a new file`

## Screenshots
_before_
<img width="953" height="660" alt="Screenshot 2026-04-08 at 3 17 00 PM" src="https://github.com/user-attachments/assets/c2190474-5397-4896-9821-7760550f4ebf" />

_after_
<img width="969" height="657" alt="Screenshot 2026-04-08 at 3 16 47 PM" src="https://github.com/user-attachments/assets/58aab405-4d00-4903-a394-92588d306e06" />

## How to test

You can upload any of these files to test different scenarios.


[not_allowed_extension.py](https://github.com/user-attachments/files/26579620/not_allowed_extension.py)
[row_validation.csv](https://github.com/user-attachments/files/26579622/row_validation.csv)
[success_partial.csv](https://github.com/user-attachments/files/26579623/success_partial.csv)
[success.csv](https://github.com/user-attachments/files/26579624/success.csv)
[fatal_error.csv](https://github.com/user-attachments/files/26579618/fatal_error.csv)
[no_records.csv](https://github.com/user-attachments/files/26579619/no_records.csv)
