### PR TITLE
PADV-3217  - Handle errors related to user creation .

### DIFF
--- a/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/__test__/indext.test.jsx
@@ -283,10 +283,14 @@ describe('Success', () => {
 
   test('Should display the correct numeric values in the partial success stat cards', async () => {
     await selectFileAndSubmit(makeFile('partial.csv'));
-    // total_rows=8, existed=2, created=6
     expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  test('Should not show the Failed stat card when failed count is zero', async () => {
+    await selectFileAndSubmit(makeFile('partial.csv'));
+    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
   });
 });
 
@@ -294,6 +298,19 @@ describe('Error', () => {
   test('Should show the error state with the failed rows description', async () => {
     await selectFileAndSubmit(makeFile('error.csv'));
     expect(screen.getByText(/we detected errors in your data/i)).toBeInTheDocument();
+  });
+
+  test('Should render the summary stat cards alongside the failed rows table', async () => {
+    await selectFileAndSubmit(makeFile('error.csv'));
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Total rows')).toBeInTheDocument();
+    expect(screen.getByText('Created Successfully')).toBeInTheDocument();
+  });
+
+  test('Should show the Failed stat card with the correct count in the error summary', async () => {
+    await selectFileAndSubmit(makeFile('error.csv'));
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getAllByText('3').length).toBeGreaterThan(0);
   });
 
   test('Should render the failed rows table with the correct column headers', async () => {

--- a/src/features/BulkRegistration/BulkRegistrationPage/columns.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/columns.jsx
@@ -1,4 +1,80 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+import { Toast } from '@edx/paragon';
+
 import StatusBadge from 'features/BulkRegistration/BulkRegistrationPage/components/StatusBadge';
+
+const fallbackCopy = (text) => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+};
+
+const copyToClipboard = async (text) => {
+  if (navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+  } else {
+    fallbackCopy(text);
+  }
+};
+
+const CopyableCell = ({ value }) => {
+  const [show, setShow] = useState(false);
+
+  const isCopyable = !value.includes('Unexpected error');
+
+  const handleCopy = useCallback(async () => {
+    if (isCopyable) { return; }
+
+    try {
+      await copyToClipboard(value);
+      setShow(true);
+    } catch (err) {
+      setShow(false);
+    }
+  }, [value, isCopyable]);
+
+  return (
+    <>
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={handleCopy}
+        onKeyDown={(e) => e.key === 'Enter' && handleCopy()}
+        style={{ cursor: 'pointer' }}
+        title={isCopyable ? value : 'Click to copy error message'}
+      >
+        {value}
+      </span>
+      <Toast
+        onClose={() => setShow(false)}
+        show={show}
+        delay={2000}
+      >
+        Error message copied to clipboard!
+      </Toast>
+    </>
+  );
+};
+
+CopyableCell.propTypes = {
+  value: PropTypes.string.isRequired,
+};
+
+const StatusCell = ({ value }) => <StatusBadge status={value} />;
+
+StatusCell.propTypes = {
+  value: PropTypes.string.isRequired,
+};
 
 export const ERROR_COLUMNS = [
   { Header: 'ROW', accessor: 'row' },
@@ -6,8 +82,11 @@ export const ERROR_COLUMNS = [
   {
     Header: 'STATUS',
     accessor: 'status',
-    // eslint-disable-next-line react/prop-types
-    Cell: ({ value }) => <StatusBadge status={value} />,
+    Cell: StatusCell,
   },
-  { Header: 'MESSAGE', accessor: 'message' },
+  {
+    Header: 'MESSAGE',
+    accessor: 'message',
+    Cell: CopyableCell,
+  },
 ];

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/ErrorRows.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/ErrorRows.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { DataTable } from '@edx/paragon';
 import { Button } from 'react-paragon-topaz';
 
+import SuccessPartial from 'features/BulkRegistration/BulkRegistrationPage/components/SuccessPartial';
 import { ERROR_COLUMNS } from '../columns';
 
 const ErrorRows = ({ data, onReset }) => (
@@ -13,7 +14,9 @@ const ErrorRows = ({ data, onReset }) => (
       it again.
     </p>
 
-    <div className="failed-rows-header">
+    <SuccessPartial data={data} onReset={onReset} disableUpload />
+
+    <div className="failed-rows-header mt-3">
       <span className="failed-rows-header__badge">
         <span className="dot dot--red" />
         Failed Rows ({data.failedRows.length})
@@ -24,7 +27,7 @@ const ErrorRows = ({ data, onReset }) => (
       </Button>
     </div>
 
-    <DataTable columns={ERROR_COLUMNS} data={data.failedRows} />
+    <DataTable columns={ERROR_COLUMNS} data={data.failedRows} itemCount={data?.failedRows?.length || 0} />
   </div>
 );
 

--- a/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessPartial.jsx
+++ b/src/features/BulkRegistration/BulkRegistrationPage/components/SuccessPartial.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Button } from 'react-paragon-topaz';
 
-const SuccessPartial = ({ data, onReset }) => (
+const SuccessPartial = ({ data, onReset, disableUpload }) => (
   <div className="state-card">
     <h2 className="summary-title">Summary</h2>
     <div className="stats-grid">
@@ -17,23 +17,37 @@ const SuccessPartial = ({ data, onReset }) => (
         <span className="stat-card__label">Created Successfully</span>
         <span className="stat-card__value">{data.createdSuccessfully}</span>
       </div>
+      {data.failedRowsCount > 0 && (
+        <div className="stat-card stat-card--error">
+          <span className="stat-card__label">Failed</span>
+          <span className="stat-card__value">{data.failedRowsCount}</span>
+        </div>
+      )}
     </div>
-    <div className="state-actions">
-      <Button type="button" className="btn btn--outline" onClick={onReset}>
-        <i className="fa-sharp fa-thin fa-file-spreadsheet" />
-        Upload a new file
-      </Button>
-    </div>
+    {!disableUpload && (
+      <div className="state-actions">
+        <Button type="button" className="btn btn--outline" onClick={onReset}>
+          <i className="fa-sharp fa-thin fa-file-spreadsheet" />
+          Upload a new file
+        </Button>
+      </div>
+    )}
   </div>
 );
 
 SuccessPartial.propTypes = {
   data: PropTypes.shape({
-    totalRows: PropTypes.number.isRequired,
+    totalRows: PropTypes.number.isRequired || PropTypes.string.isRequired,
     alreadyExisted: PropTypes.number.isRequired,
     createdSuccessfully: PropTypes.number.isRequired,
+    failedRowsCount: PropTypes.number,
   }).isRequired,
   onReset: PropTypes.func.isRequired,
+  disableUpload: PropTypes.bool,
+};
+
+SuccessPartial.defaultProps = {
+  disableUpload: false,
 };
 
 export default SuccessPartial;

--- a/src/features/BulkRegistration/BulkRegistrationPage/index.scss
+++ b/src/features/BulkRegistration/BulkRegistrationPage/index.scss
@@ -317,6 +317,13 @@ $shadow-card:      0 1px 4px rgba(0, 0, 0, 0.08);
     .stat-card__label { color: $pgn-color-green-700; }
     .stat-card__value { color: $pgn-color-green-700; }
   }
+
+  &--error {
+    background: $pgn-color-red-100;
+    border: 1px solid $pgn-color-red-300;
+    .stat-card__label { color: $pgn-color-red-500; }
+    .stat-card__value { color: $pgn-color-red-500; }
+  }
 }
 
 // ─── Error rows ───────────────────────────────────────────────────────────────

--- a/src/features/BulkRegistration/data/__test__/index.test.js
+++ b/src/features/BulkRegistration/data/__test__/index.test.js
@@ -131,6 +131,21 @@ describe('uploadCSV — happy path', () => {
     expect(result.type).toBe(BULK_REGISTRATION_STATES.ERROR_ROWS);
   });
 
+  test('Should return ERROR_ROWS result with failedRowsCount populated', async () => {
+    postBulkRegister.mockResolvedValue(
+      makeApiResponse(
+        {
+          total_rows: '3', created: '0', existed: '0', failed: '2',
+        },
+        [makeApiRow({ row_number: '2' }), makeApiRow({ row_number: '4' })],
+      ),
+    );
+
+    const result = await uploadCSV(makeFile());
+
+    expect(result.failedRowsCount).toBe(2);
+  });
+
   test('Should NOT return ERROR_ROWS when failed > 0 but rows array is empty', async () => {
     postBulkRegister.mockResolvedValue(
       makeApiResponse(
@@ -143,7 +158,6 @@ describe('uploadCSV — happy path', () => {
 
     const result = await uploadCSV(makeFile());
 
-    // No rows array → falls through to SUCCESS_ALL
     expect(result.type).toBe(BULK_REGISTRATION_STATES.SUCCESS_ALL);
   });
 });
@@ -164,7 +178,7 @@ describe('uploadCSV — parseFailedRows with object errors', () => {
 
     const { failedRows } = await uploadCSV(makeFile());
 
-    expect(failedRows[0].row).toBe(2);
+    expect(failedRows[0].row).toBe('3');
   });
 
   test('Should include the email field from the API row', async () => {
@@ -238,8 +252,8 @@ describe('uploadCSV — parseFailedRows with object errors', () => {
     const { failedRows } = await uploadCSV(makeFile());
 
     expect(failedRows).toHaveLength(2);
-    expect(failedRows[0].row).toBe(1);
-    expect(failedRows[1].row).toBe(4);
+    expect(failedRows[0].row).toBe('2');
+    expect(failedRows[1].row).toBe('5');
   });
 });
 
@@ -254,20 +268,32 @@ describe('uploadCSV — parseFailedRows with array errors', () => {
     rows,
   );
 
-  test('Should join array errors into a single comma-separated message', async () => {
+  test('Should join array errors into a single comma-separated message with support prefix', async () => {
     postBulkRegister.mockResolvedValue(
       rowsResponse([makeApiRow({ errors: ['Invalid email', 'Name required'] })]),
     );
     const { failedRows } = await uploadCSV(makeFile());
-    expect(failedRows[0].message).toBe('Invalid email, Name required');
+    expect(failedRows[0].message).toBe(
+      'Please click here and share the details below with support for further assistance:  Invalid email, Name required',
+    );
   });
 
-  test('Should use a single array error message as-is', async () => {
+  test('Should use a single array error message with the support prefix', async () => {
     postBulkRegister.mockResolvedValue(
       rowsResponse([makeApiRow({ errors: ['Row is malformed'] })]),
     );
     const { failedRows } = await uploadCSV(makeFile());
-    expect(failedRows[0].message).toBe('Row is malformed');
+    expect(failedRows[0].message).toBe(
+      'Please click here and share the details below with support for further assistance:  Row is malformed',
+    );
+  });
+
+  test('Should produce "-" when errors is an empty array', async () => {
+    postBulkRegister.mockResolvedValue(
+      rowsResponse([makeApiRow({ errors: [] })]),
+    );
+    const { failedRows } = await uploadCSV(makeFile());
+    expect(failedRows[0].message).toBe('-');
   });
 });
 
@@ -342,7 +368,7 @@ describe('uploadCSV — handleUploadError: 400 with csv_file detail+rows', () =>
 
     const result = await uploadCSV(makeFile());
 
-    expect(result.failedRows[0]).toMatchObject({ row: 2, email: 'x@x.com', status: 'Validation failed' });
+    expect(result.failedRows[0]).toMatchObject({ row: '3', email: 'x@x.com', status: 'Validation failed' });
   });
 });
 

--- a/src/features/BulkRegistration/data/index.js
+++ b/src/features/BulkRegistration/data/index.js
@@ -7,7 +7,7 @@ function parseFailedRows(rows) {
     let message = '-';
 
     if (Array.isArray(row.errors)) {
-      message = row.errors.length ? row.errors.join(', ') : '-';
+      message = row.errors.length ? `Please click here and share the details below with support for further assistance:  ${row.errors.join(', ')}` : '-';
     } else if (row.errors && typeof row.errors === 'object') {
       message = Object.entries(row.errors)
         .map(([field, msgs]) => `${field}: ${msgs?.join(', ')}`)
@@ -15,7 +15,7 @@ function parseFailedRows(rows) {
     }
 
     return {
-      row: Number(row.row_number) - 1,
+      row: row.row_number,
       email: row.email || '-',
       status: row.status,
       message,
@@ -34,6 +34,10 @@ function parseRegistrationResult(data) {
     return {
       type: BULK_REGISTRATION_STATES.ERROR_ROWS,
       failedRows: parseFailedRows(data.errors.rows),
+      totalRows,
+      alreadyExisted: existed,
+      createdSuccessfully: created,
+      failedRowsCount: failed,
     };
   }
 
@@ -69,6 +73,10 @@ function handleUploadError(error) {
       return {
         type: BULK_REGISTRATION_STATES.ERROR_ROWS,
         failedRows: parseFailedRows(csvError.rows),
+        totalRows: Number(csvError?.summary?.total_rows || 0),
+        alreadyExisted: Number(csvError?.summary?.existed || 0),
+        createdSuccessfully: Number(csvError?.summary?.created || 0),
+        failedRowsCount: Number(csvError?.summary?.failed || 0),
       };
     }
   }


### PR DESCRIPTION
# Description

In this Pr is enhanced the screen error for bulk registration

## Ticket
https://pearson.atlassian.net/browse/PADV-3217

## Screenshots
_Before_
<img width="969" height="650" alt="Screenshot 2026-04-08 at 8 23 44 PM" src="https://github.com/user-attachments/assets/5020cd05-35fc-4389-96e9-a319bb7bda96" />
_After_
<img width="962" height="893" alt="Screenshot 2026-04-08 at 7 20 29 PM" src="https://github.com/user-attachments/assets/4dc70237-0353-44dc-ba1e-795459794274" />

`FAILED_CREATE`
<img width="939" height="975" alt="Screenshot 2026-04-09 at 3 05 51 PM" src="https://github.com/user-attachments/assets/9f605bc3-14ad-4c6e-ab7c-c0ab33b5efd2" />



# How to test
Use this file
[row_validation.csv](https://github.com/user-attachments/files/26583538/row_validation.csv)

