### PR TITLE
PADV-3193 - Add start date search/filter to Classes page

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -15,6 +15,14 @@ jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(() => ({})),
 }));
 
+jest.mock('helpers', () => ({
+  ...jest.requireActual('helpers'),
+  getDefaultDates: jest.fn(() => ({
+    startDate: '2024-01-01',
+    endDate: '2024-05-31',
+  })),
+}));
+
 let axiosMock;
 
 const courseOption = {
@@ -203,6 +211,8 @@ describe('ClassesFilters Component', () => {
 
     const courseSelect = getAllByTestId('select')[0];
     const classInput = getByTestId('class_name');
+    const startDateInput = getByTestId('start_date');
+    const endDateInput = getByTestId('end_date');
     const buttonClearFilters = getByText('Reset');
 
     expect(courseSelect).toBeInTheDocument();
@@ -215,10 +225,46 @@ describe('ClassesFilters Component', () => {
       target: { value: 'test' },
     });
 
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-01-01' },
+    });
+
+    fireEvent.change(endDateInput, {
+      target: { value: '2024-07-31' },
+    });
+
     await act(async () => {
       fireEvent.click(buttonClearFilters);
     });
 
     expect(classInput).toHaveValue('');
+    expect(startDateInput).toHaveValue('2024-01-01');
+    expect(endDateInput).toHaveValue('');
+  });
+
+  test('Should apply filters including dates', async () => {
+    const resetPagination = jest.fn();
+    const { getByText, getByTestId } = renderWithProviders(
+      <ClassesFilters resetPagination={resetPagination} />,
+      { preloadedState: mockStore },
+    );
+
+    const startDateInput = getByTestId('start_date');
+    const endDateInput = getByTestId('end_date');
+    const buttonApply = getByText('Apply');
+
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-01-01' },
+    });
+
+    fireEvent.change(endDateInput, {
+      target: { value: '2024-02-01' },
+    });
+
+    await act(async () => {
+      fireEvent.click(buttonApply);
+    });
+
+    expect(buttonApply).toBeInTheDocument();
   });
 });

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -8,14 +8,26 @@ import { Select, Button } from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { initialPage } from 'features/constants';
+import { getDefaultDates, buildFilterParams } from 'helpers';
 import { fetchClassesData } from 'features/Classes/data/thunks';
 import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
 import { updateFilters, updateCurrentPage } from 'features/Classes/data/slice';
 
-const notAssignedOption = {
+const NOT_ASSIGNED_OPTION = {
   label: 'Not assigned',
   value: 'null',
+};
+
+const getInitialFilters = () => {
+  const { labelStartDate } = getDefaultDates();
+  return {
+    classFilter: '',
+    courseSelected: null,
+    instructorSelected: null,
+    startDate: labelStartDate,
+    endDate: '',
+  };
 };
 
 const ClassesFilters = ({ resetPagination }) => {
@@ -30,38 +42,56 @@ const ClassesFilters = ({ resetPagination }) => {
   const queryParams = new URLSearchParams(location.search);
   const queryNotInstructors = queryParams.get('instructors');
 
+  const [filters, setFilters] = useState(getInitialFilters);
   const [courseOptions, setCourseOptions] = useState([]);
-  const [instructorOptions, setInstructorOptions] = useState([notAssignedOption]);
-  const [courseSelected, setCourseSelected] = useState(null);
-  const [instructorSelected, setInstructorSelected] = useState(null);
-  const [classFilter, setClassFilter] = useState('');
+  const [instructorOptions, setInstructorOptions] = useState([NOT_ASSIGNED_OPTION]);
+
+  const {
+    classFilter,
+    courseSelected,
+    instructorSelected,
+    startDate,
+    endDate,
+  } = filters;
+
+  const initialFilters = getInitialFilters();
 
   const isValidClassFilter = classFilter.trim().length > 1;
-  const isButtonDisabled = courseSelected === null && instructorSelected === null && !isValidClassFilter;
+  const isButtonDisabled = courseSelected === null
+    && instructorSelected === null
+    && !isValidClassFilter
+    && startDate === initialFilters.startDate
+    && endDate === initialFilters.endDate;
+
+  const updateFilter = (key, value) => setFilters((prev) => ({ ...prev, [key]: value }));
 
   useEffect(() => {
     if (queryNotInstructors === 'null') {
-      setInstructorSelected([notAssignedOption]);
+      dispatch(updateFilters({}));
+      updateFilter('instructorSelected', NOT_ASSIGNED_OPTION);
     }
   }, [queryNotInstructors]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSelectFilters = async (e) => {
     e.preventDefault();
 
-    if (isButtonDisabled) {
-      return;
-    }
+    if (isButtonDisabled) { return; }
 
     const nullInstructor = instructorSelected?.value === 'null';
-    const notSelectedInstructor = instructorSelected?.value ? instructorSelected?.value : '';
-    const form = e.target;
-    const formData = new FormData(form);
+    const notSelectedInstructor = instructorSelected?.value ?? null;
+    const formData = new FormData(e.target);
     const courseName = formData.get('course_name');
-    formData.delete('course_name');
-    formData.append('instructors', nullInstructor ? 'null' : '');
-    formData.set('instructor', nullInstructor ? '' : notSelectedInstructor);
-    formData.append('class_name', classFilter);
-    const formJson = Object.fromEntries(formData.entries());
+
+    const { startDate: computedStartDate } = getDefaultDates(startDate);
+
+    const formJson = buildFilterParams({
+      course_name: courseName,
+      instructor: nullInstructor ? null : notSelectedInstructor,
+      instructors: nullInstructor ? 'null' : null,
+      class_name: classFilter,
+      start_date: computedStartDate,
+      end_date: endDate,
+    });
 
     try {
       dispatch(updateFilters(formJson));
@@ -73,38 +103,40 @@ const ClassesFilters = ({ resetPagination }) => {
   };
 
   const handleCleanFilters = () => {
-    dispatch(fetchClassesData(institution.id, initialPage));
+    const { startDate: computedStartDate } = getDefaultDates();
+
+    const initialDates = {
+      start_date: computedStartDate,
+      end_date: '',
+    };
+
+    dispatch(fetchClassesData(institution.id, initialPage, '', initialDates));
     resetPagination();
-    setInstructorSelected(null);
-    setCourseSelected(null);
-    dispatch(updateFilters({}));
-    setClassFilter('');
+    setFilters(getInitialFilters());
   };
 
   useEffect(() => {
     const parseCoursesToOptions = courses.length > 0
-      ? courses.map(course => ({
+      ? courses.map((course) => ({
         ...course,
         label: course.masterCourseName,
         value: course.masterCourseId,
       })) : [];
 
     const parseInstructorsToOptions = instructors?.length > 0
-      ? instructors.map(instructor => ({
+      ? instructors.map((instructor) => ({
         ...instructor,
         label: instructor.instructorName,
         value: instructor.instructorUsername,
-      }))
-      : [];
+      })) : [];
 
     setCourseOptions(parseCoursesToOptions);
-    setInstructorOptions([notAssignedOption, ...parseInstructorsToOptions]);
+    setInstructorOptions([NOT_ASSIGNED_OPTION, ...parseInstructorsToOptions]);
   }, [instructors, courses]);
 
   useEffect(() => {
     if (firstRenderPage.current) {
-      setInstructorSelected(null);
-      setCourseSelected(null);
+      setFilters((prev) => ({ ...prev, courseSelected: null, instructorSelected: null }));
     }
 
     if (Object.keys(institution).length > 0) {
@@ -115,7 +147,7 @@ const ClassesFilters = ({ resetPagination }) => {
     if (queryNotInstructors === 'null') {
       firstRenderPage.current = true;
     }
-  }, [institution, dispatch, queryNotInstructors, firstRenderPage]);
+  }, [institution, dispatch, queryNotInstructors]);
 
   return (
     <Form onSubmit={handleSelectFilters} className="w-100 px-4 d-flex flex-column align-items-center">
@@ -127,8 +159,32 @@ const ClassesFilters = ({ resetPagination }) => {
             floatingLabel="Class name"
             name="class_name"
             data-testid="class_name"
-            onChange={(e) => setClassFilter(e.target.value)}
+            onChange={(e) => updateFilter('classFilter', e.target.value)}
             value={classFilter}
+          />
+        </Form.Group>
+      </Form.Row>
+      <Form.Row className="px-0 d-flex flex-wrap w-100">
+        <Form.Group as={Col} className="w-50 px-0">
+          <Form.Control
+            type="date"
+            floatingLabel="Search start date"
+            className="my-1 mr-2"
+            name="start_date"
+            data-testid="start_date"
+            value={startDate}
+            onChange={(e) => updateFilter('startDate', e.target.value)}
+          />
+        </Form.Group>
+        <Form.Group as={Col} className="w-50 px-0">
+          <Form.Control
+            type="date"
+            floatingLabel="Search end date"
+            className="my-1 mr-0"
+            name="end_date"
+            data-testid="end_date"
+            value={endDate}
+            onChange={(e) => updateFilter('endDate', e.target.value)}
           />
         </Form.Group>
       </Form.Row>
@@ -139,7 +195,7 @@ const ClassesFilters = ({ resetPagination }) => {
             name="course_name"
             className="mr-2 select"
             options={courseOptions}
-            onChange={option => setCourseSelected(option)}
+            onChange={(option) => updateFilter('courseSelected', option)}
             value={courseSelected}
           />
         </Form.Group>
@@ -148,7 +204,7 @@ const ClassesFilters = ({ resetPagination }) => {
             placeholder="Instructor"
             name="instructor"
             options={instructorOptions}
-            onChange={option => setInstructorSelected(option)}
+            onChange={(option) => updateFilter('instructorSelected', option)}
             value={instructorSelected}
           />
         </Form.Group>

--- a/src/features/Classes/ClassesPage/index.jsx
+++ b/src/features/Classes/ClassesPage/index.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Container, Pagination } from '@openedx/paragon';
 import { useLocation } from 'react-router-dom';
 
+import { getDefaultDates } from 'helpers';
 import ClassesTable from 'features/Classes/ClassesTable';
 import ClassesFilters from 'features/Classes/ClassesFilters';
 
@@ -23,13 +24,17 @@ const ClassesPage = () => {
   const instructorsNull = { instructors: queryNotInstructors };
 
   useEffect(() => {
+    const baseFilters = {
+      start_date: getDefaultDates().startDate,
+    };
+
     if (Object.keys(selectedInstitution).length > 0) {
       if (queryNotInstructors === 'null' && !resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', instructorsNull));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...instructorsNull, ...baseFilters }));
       } else if (queryNotInstructors === 'null' && resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...stateClasses.filters, ...baseFilters }));
       } else {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...stateClasses.filters, ...baseFilters }));
       }
     }
 

--- a/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
+++ b/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
@@ -16,6 +16,14 @@ jest.mock('features/Classes/data/thunks', () => ({
   fetchClassesData: jest.fn(() => () => Promise.resolve()),
 }));
 
+jest.mock('helpers', () => ({
+  ...jest.requireActual('helpers'),
+  getDefaultDates: jest.fn(() => ({
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+  })),
+}));
+
 const mockStore = {
   main: {
     selectedInstitution: {
@@ -132,66 +140,58 @@ const mockStore = {
 
 const route = '/courses/course-v1:XXX+YYY+2023';
 
+const renderComponent = (store = mockStore) => renderWithProviders(
+  <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
+  {
+    preloadedState: store,
+    initialEntries: [route],
+  },
+);
+
 describe('CoursesDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('Should render the table and the course info', async () => {
-    const component = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
+    const { container } = renderComponent();
 
     waitFor(() => {
-      expect(component.container).toHaveTextContent('Demo Course 1 1');
-      expect(component.container).toHaveTextContent('Demo MasterCourse 1');
-      expect(component.container).toHaveTextContent('Demo MasterCourse 2');
-      expect(component.container).toHaveTextContent('Demo Class 1');
-      expect(component.container).toHaveTextContent('Demo Class 2');
-      expect(component.container).toHaveTextContent('09/21/24');
-      expect(component.container).toHaveTextContent('09/21/25');
-      expect(component.container).toHaveTextContent('1');
-      expect(component.container).toHaveTextContent('2');
-      expect(component.container).toHaveTextContent('100');
-      expect(component.container).toHaveTextContent('200');
-      expect(component.container).toHaveTextContent('instructor_1');
-      expect(component.container).toHaveTextContent('instructor_2');
+      expect(container).toHaveTextContent('Demo Course 1 1');
+      expect(container).toHaveTextContent('Demo MasterCourse 1');
+      expect(container).toHaveTextContent('Demo MasterCourse 2');
+      expect(container).toHaveTextContent('Demo Class 1');
+      expect(container).toHaveTextContent('Demo Class 2');
+      expect(container).toHaveTextContent('09/21/24');
+      expect(container).toHaveTextContent('09/21/25');
+      expect(container).toHaveTextContent('1');
+      expect(container).toHaveTextContent('2');
+      expect(container).toHaveTextContent('100');
+      expect(container).toHaveTextContent('200');
+      expect(container).toHaveTextContent('instructor_1');
+      expect(container).toHaveTextContent('instructor_2');
     });
   });
 
-  test('Should render the class filter input', () => {
-    const { getByTestId } = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
-
+  test('Should render the class name filter input', () => {
+    const { getByTestId } = renderComponent();
     expect(getByTestId('class_name')).toBeInTheDocument();
   });
 
-  test('Apply and Reset buttons should be disabled when filter is empty', () => {
-    const { getByText } = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
+  test('Should render the start date and end date filter inputs', () => {
+    const { getByTestId } = renderComponent();
+    expect(getByTestId('start_date')).toBeInTheDocument();
+    expect(getByTestId('end_date')).toBeInTheDocument();
+  });
 
+  test('Apply and Reset buttons should be disabled when no filter has changed', () => {
+    const { getByText } = renderComponent();
     expect(getByText('Apply')).toBeDisabled();
     expect(getByText('Reset')).toBeDisabled();
   });
 
-  test('Apply and Reset buttons should be enabled when filter has value', () => {
-    const { getByTestId, getByText } = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
+  test('Apply and Reset buttons should be enabled when class name has valid value', () => {
+    const { getByTestId, getByText } = renderComponent();
 
     fireEvent.change(getByTestId('class_name'), {
       target: { value: 'Demo Class' },
@@ -201,14 +201,35 @@ describe('CoursesDetailPage', () => {
     expect(getByText('Reset')).not.toBeDisabled();
   });
 
-  test('Should dispatch fetchClassesData with filter on Apply', async () => {
-    const { getByTestId, getByText } = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
+  test('Apply and Reset buttons should remain disabled when class name has less than 2 chars and dates are default', () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    fireEvent.change(getByTestId('class_name'), { target: { value: 'D' } });
+
+    expect(getByText('Apply')).toBeDisabled();
+    expect(getByText('Reset')).toBeDisabled();
+  });
+
+  test('Apply and Reset buttons should be enabled when start_date changes from default', () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    fireEvent.change(getByTestId('start_date'), { target: { value: '2023-06-01' } });
+
+    expect(getByText('Apply')).not.toBeDisabled();
+    expect(getByText('Reset')).not.toBeDisabled();
+  });
+
+  test('Apply and Reset buttons should be enabled when end_date changes from default', () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    fireEvent.change(getByTestId('end_date'), { target: { value: '2025-03-15' } });
+
+    expect(getByText('Apply')).not.toBeDisabled();
+    expect(getByText('Reset')).not.toBeDisabled();
+  });
+
+  test('Should dispatch fetchClassesData with class_name filter on Apply', async () => {
+    const { getByTestId, getByText } = renderComponent();
 
     fireEvent.change(getByTestId('class_name'), {
       target: { value: 'Demo Class' },
@@ -226,14 +247,30 @@ describe('CoursesDetailPage', () => {
     });
   });
 
-  test('Should clear filter and refetch without params on Reset', async () => {
-    const { getByTestId, getByText } = renderWithProviders(
-      <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
-      {
-        preloadedState: mockStore,
-        initialEntries: [route],
-      },
-    );
+  test('Should clear all filters and refetch', async () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    fireEvent.change(getByTestId('class_name'), { target: { value: 'Demo Class' } });
+    fireEvent.change(getByTestId('start_date'), { target: { value: '2023-06-01' } });
+    fireEvent.change(getByTestId('end_date'), { target: { value: '2023-12-31' } });
+    fireEvent.click(getByText('Reset'));
+
+    await waitFor(() => {
+      expect(getByTestId('class_name')).toHaveValue('');
+      expect(getByTestId('start_date')).toHaveValue('');
+      expect(getByTestId('end_date')).toHaveValue('');
+
+      expect(fetchClassesData).toHaveBeenLastCalledWith(
+        1,
+        1,
+        'course-v1:XXX+YYY+2023',
+        expect.objectContaining({}),
+      );
+    });
+  });
+
+  test('Should disable Apply and Reset buttons after Reset', async () => {
+    const { getByTestId, getByText } = renderComponent();
 
     fireEvent.change(getByTestId('class_name'), {
       target: { value: 'Demo Class' },
@@ -242,12 +279,8 @@ describe('CoursesDetailPage', () => {
     fireEvent.click(getByText('Reset'));
 
     await waitFor(() => {
-      expect(getByTestId('class_name')).toHaveValue('');
-      expect(fetchClassesData).toHaveBeenCalledWith(
-        1,
-        1,
-        'course-v1:XXX+YYY+2023',
-      );
+      expect(getByText('Apply')).toBeDisabled();
+      expect(getByText('Reset')).toBeDisabled();
     });
   });
 });

--- a/src/features/Courses/CoursesDetailPage/index.jsx
+++ b/src/features/Courses/CoursesDetailPage/index.jsx
@@ -24,10 +24,17 @@ import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 import { fetchClassesDataSuccess, updateCurrentPage as updateClassesCurrentPage } from 'features/Classes/data/slice';
 import { fetchCoursesDataSuccess, updateCurrentPage } from 'features/Courses/data/slice';
 
+import { getDefaultDates, buildFilterParams } from 'helpers';
 import { initialPage } from 'features/constants';
 import { useInstitutionIdQueryParam } from 'hooks';
 
 import 'features/Courses/CoursesDetailPage/index.scss';
+
+const initialFilters = {
+  classFilter: '',
+  startDate: '',
+  endDate: '',
+};
 
 const CoursesDetailPage = () => {
   const navigate = useNavigate();
@@ -40,13 +47,17 @@ const CoursesDetailPage = () => {
   const institutionRef = useRef(undefined);
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [isOpenModal, openModal, closeModal] = useToggle(false);
-  const [classFilter, setClassFilter] = useState('');
+
+  const [filters, setFilters] = useState(initialFilters);
+  const { classFilter, startDate, endDate } = filters;
+  const updateFilter = (key, value) => setFilters((prev) => ({ ...prev, [key]: value }));
 
   const defaultCourseInfo = useMemo(() => ({
     numberOfStudents: '-',
     numberOfPendingStudents: '-',
     masterCourseId: '-',
   }), []);
+
   const institution = useSelector((state) => state.main.selectedInstitution);
   const courseInfo = useSelector((state) => state.courses.selectOptions)
     .find((course) => course?.masterCourseId === courseIdDecoded) || defaultCourseInfo;
@@ -55,7 +66,15 @@ const CoursesDetailPage = () => {
   const totalStudents = courseInfo.numberOfStudents + courseInfo.numberOfPendingStudents;
   const courseDetailsLink = `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${courseInfo.masterCourseId}/home`;
 
-  const isButtonDisabled = classFilter.trim().length < 2;
+  const isButtonDisabled = classFilter.trim().length < 2
+    && startDate === initialFilters.startDate
+    && endDate === initialFilters.endDate;
+
+  const buildCurrentFilterParams = () => buildFilterParams({
+    class_name: classFilter,
+    start_date: getDefaultDates(startDate).startDate,
+    end_date: endDate,
+  });
 
   const handlePagination = (targetPage) => {
     setCurrentPage(targetPage);
@@ -65,20 +84,16 @@ const CoursesDetailPage = () => {
   const handleResetFilter = () => {
     setCurrentPage(initialPage);
     dispatch(updateCurrentPage(initialPage));
-    dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded));
-    setClassFilter('');
+    setFilters(initialFilters);
+    dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded, {}));
   };
 
   const handleFilter = async (e) => {
     e.preventDefault();
 
-    if (isButtonDisabled) {
-      return;
-    }
-    const form = e.target;
-    const formData = new FormData(form);
-    formData.append('class_name', classFilter);
-    const formJson = Object.fromEntries(formData.entries());
+    if (isButtonDisabled) { return; }
+
+    const formJson = buildCurrentFilterParams();
 
     try {
       dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded, formJson));
@@ -88,14 +103,10 @@ const CoursesDetailPage = () => {
   };
 
   useEffect(() => {
-    const initialState = {
-      results: [],
-      count: 0,
-      numPages: 0,
-    };
+    const initialState = { results: [], count: 0, numPages: 0 };
 
     if (institution.id) {
-      dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded));
+      dispatch(fetchClassesData(institution.id, initialPage, courseIdDecoded, {}));
       dispatch(fetchInstructorsOptionsData(institution.id, initialPage, { limit: false }));
       dispatch(fetchCoursesOptionsData(institution.id));
     }
@@ -104,12 +115,12 @@ const CoursesDetailPage = () => {
       dispatch(fetchCoursesDataSuccess(initialState));
       dispatch(fetchClassesDataSuccess(initialState));
     };
-  }, [dispatch, institution.id, courseIdDecoded]);
+  }, [dispatch, institution.id, courseIdDecoded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (institution.id) {
-      const filters = classFilter.trim() ? { class_name: classFilter } : {};
-      dispatch(fetchClassesData(institution.id, currentPage, courseIdDecoded, filters));
+      const filterParams = buildCurrentFilterParams();
+      dispatch(fetchClassesData(institution.id, currentPage, courseIdDecoded, filterParams));
     }
   }, [currentPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -155,6 +166,7 @@ const CoursesDetailPage = () => {
           </div>
         </div>
       </div>
+
       <div className="d-flex justify-content-end align-items-center my-3">
         <Button
           as="a"
@@ -166,9 +178,7 @@ const CoursesDetailPage = () => {
           <i className="fa-solid fa-arrow-up-right-from-square mr-2 mb-1" />
           Course content
         </Button>
-        <Button onClick={openModal}>
-          Add Class
-        </Button>
+        <Button onClick={openModal}>Add Class</Button>
         <AddClass
           isOpen={isOpenModal}
           onClose={closeModal}
@@ -176,6 +186,7 @@ const CoursesDetailPage = () => {
           finalCall={finalCall}
         />
       </div>
+
       <div className="page-content-container px-2">
         <Form onSubmit={handleFilter} className="mb-5 mt-3">
           <Form.Row className="d-flex flex-wrap w-100 mr-0 px-2">
@@ -186,11 +197,37 @@ const CoursesDetailPage = () => {
                 floatingLabel="Class name"
                 name="class_name"
                 data-testid="class_name"
-                onChange={(e) => setClassFilter(e.target.value)}
+                onChange={(e) => updateFilter('classFilter', e.target.value)}
                 value={classFilter}
               />
             </Form.Group>
+
+            <Form.Row className="d-flex flex-wrap w-100 mr-0 pl-2">
+              <Form.Group as={Col} className="w-50 px-0">
+                <Form.Control
+                  type="date"
+                  floatingLabel="Search start date"
+                  className="my-1 mr-2"
+                  name="start_date"
+                  data-testid="start_date"
+                  value={startDate}
+                  onChange={(e) => updateFilter('startDate', e.target.value)}
+                />
+              </Form.Group>
+              <Form.Group as={Col} className="w-50 px-0">
+                <Form.Control
+                  type="date"
+                  floatingLabel="Search end date"
+                  className="my-1 mr-0"
+                  name="end_date"
+                  data-testid="end_date"
+                  value={endDate}
+                  onChange={(e) => updateFilter('endDate', e.target.value)}
+                />
+              </Form.Group>
+            </Form.Row>
           </Form.Row>
+
           <Form.Group className="w-100 d-flex justify-content-end px-3">
             <Button
               onClick={handleResetFilter}
@@ -204,17 +241,18 @@ const CoursesDetailPage = () => {
             <Button type="submit" disabled={isButtonDisabled}>Apply</Button>
           </Form.Group>
         </Form>
+
         <CourseDetailTable count={classes.count} data={classes.data} />
         {classes.numPages > 1 && (
-        <Pagination
-          paginationLabel="paginationNavigation"
-          pageCount={classes.numPages}
-          currentPage={currentPage}
-          onPageSelect={handlePagination}
-          variant="reduced"
-          className="mx-auto pagination-table"
-          size="small"
-        />
+          <Pagination
+            paginationLabel="paginationNavigation"
+            pageCount={classes.numPages}
+            currentPage={currentPage}
+            onPageSelect={handlePagination}
+            variant="reduced"
+            className="mx-auto pagination-table"
+            size="small"
+          />
         )}
       </div>
     </Container>

--- a/src/helpers/__test__/index.test.js
+++ b/src/helpers/__test__/index.test.js
@@ -6,6 +6,7 @@ import {
   getInitials,
   setAssignStaffRole,
   validateCSVFile,
+  buildFilterParams,
 } from 'helpers';
 
 import { assignStaffRole } from 'features/Main/data/api';
@@ -328,5 +329,49 @@ describe('validateCSVFile', () => {
       const file = makeCSVFile('foo,bar');
       await expect(validateCSVFile(file)).rejects.toThrow('Missing required columns:');
     });
+  });
+});
+
+describe('buildFilterParams', () => {
+  test('should remove null values', () => {
+    const result = buildFilterParams({ name: 'John', age: null });
+    expect(result).toEqual({ name: 'John' });
+  });
+
+  test('should remove undefined values', () => {
+    const result = buildFilterParams({ name: 'John', age: undefined });
+    expect(result).toEqual({ name: 'John' });
+  });
+
+  test('should remove empty string values', () => {
+    const result = buildFilterParams({ name: 'John', city: '' });
+    expect(result).toEqual({ name: 'John' });
+  });
+
+  test('should remove all empty, null, and undefined values at once', () => {
+    const result = buildFilterParams({
+      name: 'John', age: null, city: '', country: undefined,
+    });
+    expect(result).toEqual({ name: 'John' });
+  });
+
+  test('should return the same object if all values are valid', () => {
+    const result = buildFilterParams({ name: 'John', age: 30, city: 'NY' });
+    expect(result).toEqual({ name: 'John', age: 30, city: 'NY' });
+  });
+
+  test('should return an empty object if all values are invalid', () => {
+    const result = buildFilterParams({ name: '', age: null, city: undefined });
+    expect(result).toEqual({});
+  });
+
+  test('should return an empty object if input is empty', () => {
+    const result = buildFilterParams({});
+    expect(result).toEqual({});
+  });
+
+  test('should keep falsy values that are not empty string, null, or undefined', () => {
+    const result = buildFilterParams({ active: false, count: 0 });
+    expect(result).toEqual({ active: false, count: 0 });
   });
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -239,3 +239,48 @@ export async function validateCSVFile(file) {
 
   return true;
 }
+
+/**
+ * Generates a default date range where the start date is 4 weeks prior to today.
+ *
+ * This is typically used for filtering data (e.g., API queries) by sending
+ * a dynamic `startDate` that represents a rolling 4-week window.
+ *
+ * @function getDefaultDates
+ * @returns {{ startDate: string }}
+ * An object containing:
+ * - startDate: A string in YYYY-MM-DD format representing the date 4 weeks ago from today.
+ *
+ * @example
+ * // If today is 2026-04-27
+ * getDefaultDates();
+ * // returns: { startDate: "2026-03-30" }
+ */
+export const getDefaultDates = (startDate) => {
+  const start = startDate ? new Date(startDate) : new Date();
+
+  const fourWeeksAgo = new Date(
+    start.getTime() - (28 * 24 * 60 * 60 * 1000),
+  );
+
+  const toISO = (date) => date.toISOString().split('T')[0];
+
+  return {
+    startDate: toISO(fourWeeksAgo),
+    labelStartDate: toISO(start),
+  };
+};
+
+/**
+ * Filters out empty, null, or undefined values from a parameters object.
+ *
+ * @param {Object} params - The object containing key-value pairs to filter.
+ * @returns {Object} A new object containing only entries with non-empty, non-null, and non-undefined values.
+ *
+ * @example
+ * buildFilterParams({ name: 'John', age: null, city: '', country: 'US' });
+ * // Returns: { name: 'John', country: 'US' }
+ */
+export const buildFilterParams = (params) => Object.fromEntries(
+  Object.entries(params).filter(([, value]) => value !== '' && value !== null && value !== undefined),
+);


### PR DESCRIPTION
# Description
In this PR is added date filters for classes.

## Ticket
https://pearson.atlassian.net/browse/PADV-3193

## Screenshots
<img width="1467" height="703" alt="Screenshot 2026-04-27 at 5 11 02 PM" src="https://github.com/user-attachments/assets/3afb6171-ec6d-47ed-b83c-8c7420793790" />

-

<img width="1457" height="1015" alt="Screenshot 2026-04-27 at 5 10 42 PM" src="https://github.com/user-attachments/assets/43f75032-2b0a-480d-a65c-b292b8cac94e" />

## How to test
- Go to /classes or /courses/:classId