### PR TITLE
fix: remove getDefaultDates in courseDetailPage

### DIFF
--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -82,14 +82,12 @@ const ClassesFilters = ({ resetPagination }) => {
     const formData = new FormData(e.target);
     const courseName = formData.get('course_name');
 
-    const { startDate: computedStartDate } = getDefaultDates(startDate);
-
     const formJson = buildFilterParams({
       course_name: courseName,
       instructor: nullInstructor ? null : notSelectedInstructor,
       instructors: nullInstructor ? 'null' : null,
       class_name: classFilter,
-      start_date: computedStartDate,
+      start_date: startDate,
       end_date: endDate,
     });
 

--- a/src/features/Courses/CoursesDetailPage/index.jsx
+++ b/src/features/Courses/CoursesDetailPage/index.jsx
@@ -24,7 +24,7 @@ import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 import { fetchClassesDataSuccess, updateCurrentPage as updateClassesCurrentPage } from 'features/Classes/data/slice';
 import { fetchCoursesDataSuccess, updateCurrentPage } from 'features/Courses/data/slice';
 
-import { getDefaultDates, buildFilterParams } from 'helpers';
+import { buildFilterParams } from 'helpers';
 import { initialPage } from 'features/constants';
 import { useInstitutionIdQueryParam } from 'hooks';
 
@@ -72,7 +72,7 @@ const CoursesDetailPage = () => {
 
   const buildCurrentFilterParams = () => buildFilterParams({
     class_name: classFilter,
-    start_date: getDefaultDates(startDate).startDate,
+    start_date: startDate,
     end_date: endDate,
   });
 


### PR DESCRIPTION
# Description

In this PR is removed the logic that subtracts four weeks in start date filter for classes, is not required for the feature. 

## How to test

Use the clases filters the date selected must be sent without any alteration.