### PR TITLE
feat: enhance date handling by updating getDefaultDates to return endDate 

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -239,7 +239,7 @@ describe('ClassesFilters Component', () => {
 
     expect(classInput).toHaveValue('');
     expect(startDateInput).toHaveValue('2024-01-01');
-    expect(endDateInput).toHaveValue('');
+    expect(endDateInput).toHaveValue('2024-05-31');
   });
 
   test('Should apply filters including dates', async () => {

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -20,13 +20,14 @@ const NOT_ASSIGNED_OPTION = {
 };
 
 const getInitialFilters = () => {
-  const { labelStartDate } = getDefaultDates();
+  const { startDate, endDate } = getDefaultDates();
+
   return {
     classFilter: '',
     courseSelected: null,
     instructorSelected: null,
-    startDate: labelStartDate,
-    endDate: '',
+    startDate,
+    endDate,
   };
 };
 
@@ -101,11 +102,14 @@ const ClassesFilters = ({ resetPagination }) => {
   };
 
   const handleCleanFilters = () => {
-    const { startDate: computedStartDate } = getDefaultDates();
+    const {
+      startDate: computedStartDate,
+      endDate: computedEndDate,
+    } = getDefaultDates();
 
     const initialDates = {
       start_date: computedStartDate,
-      end_date: '',
+      end_date: computedEndDate,
     };
 
     dispatch(fetchClassesData(institution.id, initialPage, '', initialDates));

--- a/src/features/Classes/ClassesPage/index.jsx
+++ b/src/features/Classes/ClassesPage/index.jsx
@@ -26,6 +26,7 @@ const ClassesPage = () => {
   useEffect(() => {
     const baseFilters = {
       start_date: getDefaultDates().startDate,
+      end_date: getDefaultDates().endDate,
     };
 
     if (Object.keys(selectedInstitution).length > 0) {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -241,33 +241,40 @@ export async function validateCSVFile(file) {
 }
 
 /**
- * Generates a default date range where the start date is 4 weeks prior to today.
+ * Generates a default date range:
+ * - startDate: 4 weeks prior to the reference date
+ * - endDate: 2 weeks after the reference date
  *
- * This is typically used for filtering data (e.g., API queries) by sending
- * a dynamic `startDate` that represents a rolling 4-week window.
+ * The reference date is `startDate` if provided, otherwise today.
  *
  * @function getDefaultDates
- * @returns {{ startDate: string }}
+ * @param {string} [startDate] - Optional base date in YYYY-MM-DD format.
+ * @returns {{ startDate: string, endDate: string }}
  * An object containing:
- * - startDate: A string in YYYY-MM-DD format representing the date 4 weeks ago from today.
+ * - startDate: YYYY-MM-DD string (4 weeks before reference date)
+ * - endDate: YYYY-MM-DD string (2 weeks after reference date)
  *
  * @example
  * // If today is 2026-04-27
  * getDefaultDates();
- * // returns: { startDate: "2026-03-30" }
+ * // returns: { startDate: "2026-03-30", endDate: "2026-05-11" }
  */
 export const getDefaultDates = (startDate) => {
-  const start = startDate ? new Date(startDate) : new Date();
+  const base = startDate ? new Date(startDate) : new Date();
 
   const fourWeeksAgo = new Date(
-    start.getTime() - (28 * 24 * 60 * 60 * 1000),
+    base.getTime() - (28 * 24 * 60 * 60 * 1000),
+  );
+
+  const twoWeeksAhead = new Date(
+    base.getTime() + (14 * 24 * 60 * 60 * 1000),
   );
 
   const toISO = (date) => date.toISOString().split('T')[0];
 
   return {
     startDate: toISO(fourWeeksAgo),
-    labelStartDate: toISO(start),
+    endDate: toISO(twoWeeksAhead),
   };
 };
 


### PR DESCRIPTION
# Description

In this pr is adjusted the date filters to include the end search date.

## How to test

- Go to /classes
- You should see the start date and the endDate on page load.