### PR TITLE
PADV-3368 - Drop default search range from Classes page

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -15,14 +15,6 @@ jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(() => ({})),
 }));
 
-jest.mock('helpers', () => ({
-  ...jest.requireActual('helpers'),
-  getDefaultDates: jest.fn(() => ({
-    startDate: '2024-01-01',
-    endDate: '2024-05-31',
-  })),
-}));
-
 let axiosMock;
 
 const courseOption = {
@@ -238,8 +230,8 @@ describe('ClassesFilters Component', () => {
     });
 
     expect(classInput).toHaveValue('');
-    expect(startDateInput).toHaveValue('2024-01-01');
-    expect(endDateInput).toHaveValue('2024-05-31');
+    expect(startDateInput).toHaveValue('');
+    expect(endDateInput).toHaveValue('');
   });
 
   test('Should apply filters including dates', async () => {

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -8,7 +8,7 @@ import { Select, Button } from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { initialPage } from 'features/constants';
-import { getDefaultDates, buildFilterParams } from 'helpers';
+import { buildFilterParams } from 'helpers';
 import { fetchClassesData } from 'features/Classes/data/thunks';
 import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
 import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
@@ -19,17 +19,13 @@ const NOT_ASSIGNED_OPTION = {
   value: 'null',
 };
 
-const getInitialFilters = () => {
-  const { startDate, endDate } = getDefaultDates();
-
-  return {
-    classFilter: '',
-    courseSelected: null,
-    instructorSelected: null,
-    startDate,
-    endDate,
-  };
-};
+const getInitialFilters = () => ({
+  classFilter: '',
+  courseSelected: null,
+  instructorSelected: null,
+  startDate: '',
+  endDate: '',
+});
 
 const ClassesFilters = ({ resetPagination }) => {
   const dispatch = useDispatch();
@@ -102,17 +98,7 @@ const ClassesFilters = ({ resetPagination }) => {
   };
 
   const handleCleanFilters = () => {
-    const {
-      startDate: computedStartDate,
-      endDate: computedEndDate,
-    } = getDefaultDates();
-
-    const initialDates = {
-      start_date: computedStartDate,
-      end_date: computedEndDate,
-    };
-
-    dispatch(fetchClassesData(institution.id, initialPage, '', initialDates));
+    dispatch(fetchClassesData(institution.id, initialPage));
     resetPagination();
     setFilters(getInitialFilters());
   };

--- a/src/features/Classes/ClassesPage/index.jsx
+++ b/src/features/Classes/ClassesPage/index.jsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Container, Pagination } from '@openedx/paragon';
 import { useLocation } from 'react-router-dom';
 
-import { getDefaultDates } from 'helpers';
 import ClassesTable from 'features/Classes/ClassesTable';
 import ClassesFilters from 'features/Classes/ClassesFilters';
 
@@ -24,18 +23,13 @@ const ClassesPage = () => {
   const instructorsNull = { instructors: queryNotInstructors };
 
   useEffect(() => {
-    const baseFilters = {
-      start_date: getDefaultDates().startDate,
-      end_date: getDefaultDates().endDate,
-    };
-
     if (Object.keys(selectedInstitution).length > 0) {
       if (queryNotInstructors === 'null' && !resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...instructorsNull, ...baseFilters }));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', instructorsNull));
       } else if (queryNotInstructors === 'null' && resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...stateClasses.filters, ...baseFilters }));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
       } else {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', { ...stateClasses.filters, ...baseFilters }));
+        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
       }
     }
 

--- a/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
+++ b/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
@@ -16,14 +16,6 @@ jest.mock('features/Classes/data/thunks', () => ({
   fetchClassesData: jest.fn(() => () => Promise.resolve()),
 }));
 
-jest.mock('helpers', () => ({
-  ...jest.requireActual('helpers'),
-  getDefaultDates: jest.fn(() => ({
-    startDate: '2024-01-01',
-    endDate: '2024-12-31',
-  })),
-}));
-
 const mockStore = {
   main: {
     selectedInstitution: {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -241,44 +241,6 @@ export async function validateCSVFile(file) {
 }
 
 /**
- * Generates a default date range:
- * - startDate: 4 weeks prior to the reference date
- * - endDate: 2 weeks after the reference date
- *
- * The reference date is `startDate` if provided, otherwise today.
- *
- * @function getDefaultDates
- * @param {string} [startDate] - Optional base date in YYYY-MM-DD format.
- * @returns {{ startDate: string, endDate: string }}
- * An object containing:
- * - startDate: YYYY-MM-DD string (4 weeks before reference date)
- * - endDate: YYYY-MM-DD string (2 weeks after reference date)
- *
- * @example
- * // If today is 2026-04-27
- * getDefaultDates();
- * // returns: { startDate: "2026-03-30", endDate: "2026-05-11" }
- */
-export const getDefaultDates = (startDate) => {
-  const base = startDate ? new Date(startDate) : new Date();
-
-  const fourWeeksAgo = new Date(
-    base.getTime() - (28 * 24 * 60 * 60 * 1000),
-  );
-
-  const twoWeeksAhead = new Date(
-    base.getTime() + (14 * 24 * 60 * 60 * 1000),
-  );
-
-  const toISO = (date) => date.toISOString().split('T')[0];
-
-  return {
-    startDate: toISO(fourWeeksAgo),
-    endDate: toISO(twoWeeksAhead),
-  };
-};
-
-/**
  * Filters out empty, null, or undefined values from a parameters object.
  *
  * @param {Object} params - The object containing key-value pairs to filter.


### PR DESCRIPTION
# Description
This PR updates the default behavior of the date filters located at `/admin/classes?institutionId=`.

Previously, the filters were automatically populated with default dates calculated based on specific business requirements. This behavior has been removed since it is no longer considered necessary.

Now, the date inputs are displayed empty by default, and the classes list is loaded without applying any initial date filters.

## Ticket

https://pearson.atlassian.net/browse/PADV-3368

## Changes
- Removed the default start and end date values from the classes filters
- Updated the initial page load behavior to fetch classes without date filters
- Deleted `getDefaultDates` not longer in use

## How to test
- Start the application locally
- Navigate to `/classes`
- Verify that the date inputs are empty on initial load
- Verify that the first request fetches classes without date filter parameters
- Verify that classes are displayed correctly
- Modify the date filters
- Verify that the selected dates are included in the request filter parameters