### PR TITLE
PADV-3363 - Class search - by course

### DIFF
--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -80,7 +80,6 @@ const ClassesFilters = ({ resetPagination }) => {
     const courseName = formData.get('course_name');
 
     const formJson = buildFilterParams({
-      course_name: courseName,
       instructor: nullInstructor ? null : notSelectedInstructor,
       instructors: nullInstructor ? 'null' : null,
       class_name: classFilter,


### PR DESCRIPTION
# Description
This task fixes the course filter behavior in the classes page.

The issue was caused because the request was sending the `courseId` value through a query parameter named `course_name`, which prevented the API from returning results correctly.

## Ticket
https://pearson.atlassian.net/browse/PADV-3363

## Changes
- Fixed the course filter request parameters
- Removed the incorrect `course_name` query parameter from the request
- Restored correct results when filtering classes by course

## How to test
- Start the application locally
- Navigate to `/classes`
- Apply a course filter
- Verify that the request contains only the `course_id` query parameter
- Verify that the request does not include a `course_name` query parameter
- Verify that the classes are filtered correctly based on the selected course