### PR TITLE
PADV-3410 - Modify Support link in PSS

### DIFF
--- a/src/features/Main/Sidebar/_test_/index.test.jsx
+++ b/src/features/Main/Sidebar/_test_/index.test.jsx
@@ -22,10 +22,18 @@ jest.mock('react-paragon-topaz', () => ({
   getUserRoles: jest.fn(() => (['INSTITUTION_ADMIN'])),
 }));
 
+const defaultInitialState = {
+  main: {
+    activeTab: 'dashboard',
+    selectedInstitution: {},
+  },
+};
+
 describe('Sidebar', () => {
   test('should render properly', () => {
     const { getByRole } = renderWithProviders(
       <Sidebar />,
+      { preloadedState: defaultInitialState },
     );
 
     const studentsTabButton = getByRole('button', { name: /students/i });
@@ -42,10 +50,40 @@ describe('Sidebar', () => {
 
     const { getByText } = renderWithProviders(
       <Sidebar />,
+      { preloadedState: defaultInitialState },
     );
 
     const portalLink = getByText('Instructor Portal');
-
     expect(portalLink).toBeInTheDocument();
+  });
+
+  test('should use institution supportLink for Contact Support when provided', () => {
+    const customSupportLink = 'https://custom-support.example.com';
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      {
+        preloadedState: {
+          ...defaultInitialState,
+          main: {
+            ...defaultInitialState.main,
+            selectedInstitution: { supportLink: customSupportLink },
+          },
+        },
+      },
+    );
+
+    const contactSupportLink = getByText('Contact Support').closest('a');
+    expect(contactSupportLink).toHaveAttribute('href', customSupportLink);
+  });
+
+  test('should use default Contact Support link when institution has no supportLink', () => {
+    const defaultSupportLink = 'https://skilling.pearsonvue.com/pearson-core/support/';
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      { preloadedState: defaultInitialState },
+    );
+
+    const contactSupportLink = getByText('Contact Support').closest('a');
+    expect(contactSupportLink).toHaveAttribute('href', defaultSupportLink);
   });
 });

--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -58,6 +58,7 @@ export const Sidebar = () => {
   const activeTab = useSelector((state) => state.main.activeTab);
   const menuItems = [...baseItems];
   const instructorPortalPath = getConfig().INSTRUCTOR_PORTAL_PATH || '';
+  const institution = useSelector((state) => state.main.selectedInstitution);
 
   if (roles.includes(USER_ROLES.INSTRUCTOR) && instructorPortalPath.length > 0) {
     menuItems.push({
@@ -119,15 +120,21 @@ export const Sidebar = () => {
             link,
             label,
             ...rest
-          }) => (
-            <MenuItem
-              key={link}
-              title={label}
-              as="a"
-              href={link}
-              {...rest}
-            />
-          ))
+          }) => {
+            const resolvedLink = label === 'Contact Support' && institution?.supportLink
+              ? institution.supportLink
+              : link;
+
+            return (
+              <MenuItem
+                key={label}
+                title={label}
+                as="a"
+                href={resolvedLink}
+                {...rest}
+              />
+            );
+          })
         }
       </MenuSection>
     </SidebarBase>


### PR DESCRIPTION
# Description

This PR updates the support link behavior by reading the `support_link` value configured in the institution. If the institution does not provide a support link, the application falls back to the default support link value.

The support link is configured through the Django Admin and consumed by the MFE.

## Ticket
https://pearson.atlassian.net/browse/PADV-3410

## Changes

* Added support link retrieval from the institution configuration.
* Added fallback logic to use the default support link when no institution support link is provided.
* Connected the MFE to consume the institution support link value.
* Support link remains read-only from the MFE and configurable only through Django Admin.

## How to test

* Open Django Admin.
* Navigate to `Home › course_operations › Institutions`.
* Select the desired institution.
* Configure the `Support link` field and save the changes.
* Start the MFE application.
* Verify that the configured institution support link is displayed correctly in the MFE.
* Remove or leave the `Support link` field empty in Django Admin.
* Verify that the application uses the default support link value when no institution support link is configured.
