### PR TITLE
PADV-3372 feat: responsive tables

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -77,3 +77,22 @@ a.epp-link {
     min-width: 680px;
   }
 }
+
+.responsive-data-table {
+  width: 100%;
+  overflow-x: auto;
+
+  .pgn__data-table-cell-wrap {
+        max-width: 15vw;
+  }
+}
+
+.responsive-data-table table {
+  width: 100%;
+  min-width: max-content;
+}
+
+.responsive-data-table td,
+.responsive-data-table th {
+  overflow-wrap: anywhere;
+}

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -34,7 +34,7 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.learnerName}
         </Link>
@@ -185,7 +185,7 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               target="_blank"
               rel="noreferrer"

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -34,7 +34,7 @@ const columns = [
     Cell: ({ row }) => (
       <LinkWithQuery
         to={`/courses/${encodeURIComponent(row.original.masterCourseId)}/${encodeURIComponent(row.original.classId)}?previous=classes`}
-        className="text-truncate link"
+        className="link"
       >
         {row.values.className}
       </LinkWithQuery>
@@ -44,7 +44,7 @@ const columns = [
     Header: 'Course Title',
     accessor: 'masterCourseName',
     Cell: ({ row }) => (
-      <span className="text-truncate">
+      <span>
         {row.original.masterCourseName}
       </span>
     ),
@@ -65,7 +65,7 @@ const columns = [
               );
 
               return (
-                <li key={instructorUsername} className="text-truncate">
+                <li key={instructorUsername}>
                   {instructorData?.instructorName || instructorUsername}
                 </li>
               );
@@ -224,7 +224,7 @@ const columns = [
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               target="_blank"
               rel="noreferrer"

--- a/src/features/Classes/ClassesTable/index.jsx
+++ b/src/features/Classes/ClassesTable/index.jsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Row, Col, DataTable } from '@openedx/paragon';
+import { Row, Col } from '@openedx/paragon';
 import { columns } from 'features/Classes/ClassesTable/columns';
 import { RequestStatus } from 'features/constants';
+import Table from 'features/Main/Table';
 
 const ClassesTable = ({ data, count }) => {
   const classesRequest = useSelector((state) => state.classes.table.status);
@@ -13,17 +14,14 @@ const ClassesTable = ({ data, count }) => {
   return (
     <Row className="justify-content-center my-4 my-3 mx-0">
       <Col xs={12} className="px-4">
-        <DataTable
+        <Table
           isLoading={isLoading}
           isSortable
           columns={COLUMNS}
           itemCount={count}
           data={data}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content="No classes found." />
-          <DataTable.TableFooter />
-        </DataTable>
+          text="No classes found."
+        />
       </Col>
     </Row>
   );

--- a/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
+++ b/src/features/Courses/CourseDetailTable/__test__/columns.test.jsx
@@ -82,7 +82,7 @@ describe('columns', () => {
 
     const linkElement = screen.getByText('Class example');
     expect(linkElement).toBeInTheDocument();
-    expect(linkElement).toHaveClass('text-truncate link');
+    expect(linkElement).toHaveClass('link');
     expect(linkElement).toHaveAttribute('href');
     expect(linkElement.getAttribute('href')).toContain('course-v1:XXX+YYY+2023');
     expect(linkElement.getAttribute('href')).toContain('class%20id');

--- a/src/features/Courses/CourseDetailTable/columns.jsx
+++ b/src/features/Courses/CourseDetailTable/columns.jsx
@@ -40,7 +40,7 @@ const columns = [
       return (
         <LinkWithQuery
           to={`/courses/${courseId}/${encodeURIComponent(row.original.classId)}?previous=courses`}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.className}
         </LinkWithQuery>
@@ -51,7 +51,7 @@ const columns = [
     Header: 'Course Title',
     accessor: 'masterCourseName',
     Cell: ({ row }) => (
-      <span className="text-truncate">
+      <span>
         {row.original.masterCourseName}
       </span>
     ),
@@ -72,7 +72,7 @@ const columns = [
               );
 
               return (
-                <li key={instructorUsername} className="text-truncate">
+                <li key={instructorUsername}>
                   {instructorData?.instructorName || instructorUsername}
                 </li>
               );
@@ -193,7 +193,7 @@ const columns = [
               data-testid="droprown-action"
               alt="menu for actions"
             />
-            <Dropdown.Menu>
+            <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
               <Dropdown.Item
                 target="_blank"
                 rel="noreferrer"

--- a/src/features/Courses/CourseDetailTable/index.jsx
+++ b/src/features/Courses/CourseDetailTable/index.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { DataTable } from '@openedx/paragon';
+import Table from 'features/Main/Table';
 
 import { columns } from 'features/Courses/CourseDetailTable/columns';
 import { RequestStatus } from 'features/constants';
@@ -12,17 +12,14 @@ const CourseDetailTable = ({ data, count }) => {
   const isLoading = classesRequest === RequestStatus.LOADING;
 
   return (
-    <DataTable
+    <Table
       isLoading={isLoading}
       isSortable
       columns={COLUMNS}
       itemCount={count}
       data={data}
-    >
-      <DataTable.Table />
-      <DataTable.EmptyTable content="No classes were found." />
-      <DataTable.TableFooter />
-    </DataTable>
+      text="No classes were found."
+    />
   );
 };
 

--- a/src/features/Courses/CoursesTable/columns.jsx
+++ b/src/features/Courses/CoursesTable/columns.jsx
@@ -68,7 +68,7 @@ const columns = [
             data-testid="droprown-action"
             alt="menu for action"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item href={courseDetailsLink} target="_blank" rel="noopener noreferrer">
               <i className="fa-solid fa-arrow-up-right-from-square mr-2 mb-1" />
               Course content

--- a/src/features/Courses/CoursesTable/index.jsx
+++ b/src/features/Courses/CoursesTable/index.jsx
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Row, Col, DataTable } from '@openedx/paragon';
+import { Row, Col } from '@openedx/paragon';
+import Table from 'features/Main/Table';
 
 import { columns } from 'features/Courses/CoursesTable/columns';
 import { RequestStatus } from 'features/constants';
@@ -16,17 +17,14 @@ const CoursesTable = ({ data, count }) => {
   return (
     <Row className="justify-content-center my-4 my-3">
       <Col xs={11} className="p-0">
-        <DataTable
+        <Table
           isLoading={isLoading}
           isSortable
           columns={COLUMNS}
           itemCount={count}
           data={data}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content="No courses found." />
-          <DataTable.TableFooter />
-        </DataTable>
+          text="No courses found."
+        />
       </Col>
     </Row>
   );

--- a/src/features/Instructors/InstructorsTable/columns.jsx
+++ b/src/features/Instructors/InstructorsTable/columns.jsx
@@ -99,7 +99,7 @@ const getColumns = (showInstructorFeature) => [
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               className="text-truncate text-decoration-none custom-text-black"
               onClick={openModal}

--- a/src/features/Instructors/InstructorsTable/index.jsx
+++ b/src/features/Instructors/InstructorsTable/index.jsx
@@ -6,8 +6,8 @@ import { getConfig } from '@edx/frontend-platform';
 import {
   Row,
   Col,
-  DataTable,
 } from '@openedx/paragon';
+import Table from 'features/Main/Table';
 
 import { getColumns } from 'features/Instructors/InstructorsTable/columns';
 import { RequestStatus } from 'features/constants';
@@ -24,17 +24,14 @@ const InstructorsTable = ({
   return (
     <Row className="justify-content-center my-4 my-3">
       <Col xs={11} className="p-0">
-        <DataTable
+        <Table
           isLoading={isLoading}
           isSortable
           columns={COLUMNS}
           itemCount={count}
           data={data}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content="No instructors found." />
-          <DataTable.TableFooter />
-        </DataTable>
+          text="No instructors found."
+        />
       </Col>
     </Row>
   );

--- a/src/features/Licenses/LicensesTable/index.jsx
+++ b/src/features/Licenses/LicensesTable/index.jsx
@@ -2,8 +2,9 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Row, Col, DataTable } from '@openedx/paragon';
+import { Row, Col } from '@openedx/paragon';
 import { columns } from 'features/Licenses/LicensesTable/columns';
+import Table from 'features/Main/Table';
 
 import { RequestStatus } from 'features/constants';
 
@@ -15,16 +16,14 @@ const LicensesTable = ({ data, count }) => {
   return (
     <Row className="justify-content-center my-4 my-3 mx-0">
       <Col xs={12} className="px-4">
-        <DataTable
+        <Table
           isLoading={isLoading}
           isSortable
           columns={COLUMNS}
           itemCount={count}
           data={data}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content="No licenses found." />
-        </DataTable>
+          text="No licenses found."
+        />
       </Col>
     </Row>
   );

--- a/src/features/Main/Table/index.jsx
+++ b/src/features/Main/Table/index.jsx
@@ -12,17 +12,19 @@ const Table = ({
   const COLUMNS = useMemo(() => columns, [columns]);
 
   return (
-    <DataTable
-      isSortable
-      columns={COLUMNS}
-      itemCount={count}
-      data={data}
-      {...props}
-    >
-      <DataTable.Table />
-      <DataTable.EmptyTable content={text} />
-      <DataTable.TableFooter />
-    </DataTable>
+    <div className="responsive-data-table">
+      <DataTable
+        isSortable
+        columns={COLUMNS}
+        itemCount={count}
+        data={data}
+        {...props}
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content={text} />
+        <DataTable.TableFooter />
+      </DataTable>
+    </div>
   );
 };
 

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -28,7 +28,7 @@ const columns = [
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.learnerName}
         </Link>
@@ -62,7 +62,7 @@ const columns = [
     Cell: ({ row }) => (
       <LinkWithQuery
         to={`/courses/${encodeURIComponent(row.original.courseId)}/${encodeURIComponent(row.original.classId)}`}
-        className="text-truncate link"
+        className="link"
       >
         {row.values.className}
       </LinkWithQuery>
@@ -184,7 +184,7 @@ const columns = [
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               target="_blank"
               rel="noreferrer"

--- a/src/features/Students/StudentsTable/index.jsx
+++ b/src/features/Students/StudentsTable/index.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import {
   Row,
   Col,
-  DataTable,
 } from '@openedx/paragon';
 
 import { columns } from 'features/Students/StudentsTable/columns';
 import { RequestStatus } from 'features/constants';
+import Table from 'features/Main/Table';
 
 const StudentsTable = ({
   data,
@@ -21,17 +21,14 @@ const StudentsTable = ({
   return (
     <Row className="justify-content-center my-4 my-3">
       <Col xs={11} className="p-0">
-        <DataTable
+        <Table
           isLoading={isLoading}
           isSortable
           itemCount={count}
           data={data}
           columns={COLUMNS}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content="No students found." />
-          <DataTable.TableFooter />
-        </DataTable>
+          text="No students found."
+        />
       </Col>
     </Row>
   );


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-3372

### Description
To make the tables in the portal responsive, if the screen is narrow, the x-scroll will be activated to prevent the table from going outside the container.

### Changes made
Use the table component to avoid code repetion
Add responsive table classes
Add property in menu dropdown to avoid the menu be hide with the scroll

### Screenshoots
Before
<img width="1569" height="588" alt="image" src="https://github.com/user-attachments/assets/29e130d9-b008-41c3-94aa-f984311f860a" />

After
<img width="1421" height="625" alt="image" src="https://github.com/user-attachments/assets/77fe0820-5ee1-4fc8-a0e1-0df4d855d351" />


### How to test
Clone the Institution Portal MFE
npm install
npm start