### PR TITLE
fix: error with students call service

### DIFF
--- a/src/features/Classes/Class/ClassPage/index.jsx
+++ b/src/features/Classes/Class/ClassPage/index.jsx
@@ -194,17 +194,19 @@ const ClassPage = () => {
       };
 
       dispatch(fetchStudentsData(institution.id, currentPage, params));
-
-      if (displayVoucherOptions) {
-        dispatch(fetchStudentsVouchers(displayVoucherOptions));
-      }
     }
 
     return () => {
       dispatch(resetStudentsTable());
       dispatch(updateCurrentPage(initialPage));
     };
-  }, [dispatch, institution.id, courseIdDecoded, classIdDecoded, currentPage, displayVoucherOptions]);
+  }, [dispatch, institution.id, courseIdDecoded, classIdDecoded, currentPage]);
+
+  useEffect(() => {
+    if (institution.id && displayVoucherOptions) {
+      dispatch(fetchStudentsVouchers(displayVoucherOptions));
+    }
+  }, [dispatch, institution.id, displayVoucherOptions]);
 
   useEffect(() => {
     if (institution.id) {


### PR DESCRIPTION
## Ticket 
https://pearson.atlassian.net/browse/PADV-3440

##  Description
This PR resolves a critical production race condition inside the `ClassPage` component where the student data service (`fetchStudentsData`) was being triggered twice during the initial mounting phase. 

### The Root Cause
The issue stemmed from an over-indexed dependency array in the main data-fetching `useEffect`. The hook depended on `displayVoucherOptions`, which relies directly on the async response of the class metadata query (`fetchAllClassesData`). 

In high-latency environments (such as Production), the sequence unfolded as follows:
1. Component mounts -> `classInfo` defaults to an empty object -> `displayVoucherOptions` evaluates to `undefined`.
2. The `useEffect` triggers the **1st network call** to fetch student data.
3. A few seconds later, the async class metadata arrives -> `classInfo` updates -> `displayVoucherOptions` transitions from `undefined` to a concrete string value.
4. React detects a value change in the dependency array -> runs the hook cleanup (`resetStudentsTable()`) -> triggers a **2nd redundant network call** to fetch student data.

By uncoupling student data queries from class metadata dependencies, we have isolated these network streams, drastically reducing payload overhead and securing a single source of truth during loading states.

## Changes Made
* **Decoupled Main Effect:** Separated the monolithic loading `useEffect` inside `ClassPage.jsx` into standalone, single-responsibility side effects.
* **Isolated Student Query:** The hook firing `fetchStudentsData` now strictly targets route navigation criteria (`courseIdDecoded`, `classIdDecoded`, `currentPage`) and the initial `institution.id` verification state.
* **Isolated Voucher Query:** Isolated `fetchStudentsVouchers` into its own lightweight effect that listens exclusively to `displayVoucherOptions` transitions without tearing down the student data table.

### Before
https://github.com/user-attachments/assets/ed599e18-b99d-408e-9d59-16d7f2435f02

### After
https://github.com/user-attachments/assets/bf9c34af-fc4c-478a-8984-9306e94b9553

## How to Test

### 1. Local Network Emulation (Simulating the Production Desfase)
To accurately simulate the production race condition locally where API services respond at different intervals:
1. Open Chrome Developer Tools (`F12`) and navigate to the **Network** tab.
2. Under the Throttling dropdown menu, select **Add...** to create a custom profile.
3. Configure a profile named `Production Simulation` with a high **Latency (Ping)** parameter set to `3500ms` or `4000ms`.
4. Enable the profile, hard-refresh the browser, and land on a Class Page.
5. **Verification:** Inspect the network log streams. Confirm that the `fetch-students` endpoint is hit **exactly once**, even if the class metadata endpoints complete several seconds later.

