### PR TITLE
feat: update instructor filters and tests for active status

### DIFF
--- a/src/features/Instructors/InstructorsFilters/index.jsx
+++ b/src/features/Instructors/InstructorsFilters/index.jsx
@@ -103,9 +103,13 @@ const InstructorsFilters = ({ resetPagination, isAssignSection, onResetFilters }
   const isSameFiltersData = usePreviousValueCompare(requestPayload);
 
   const handleCleanFilters = () => {
+    const resetFilters = { active: true };
+
+    dispatch(updateFilters(resetFilters));
     dispatch(fetchInstructorsData(
       selectedInstitution?.id,
       initialPage,
+      resetFilters,
     ));
 
     if (onResetFilters) {
@@ -113,7 +117,6 @@ const InstructorsFilters = ({ resetPagination, isAssignSection, onResetFilters }
     }
 
     resetPagination();
-    dispatch(updateFilters({}));
     resetFields();
   };
 

--- a/src/features/Instructors/InstructorsPage/_test_/index.test.jsx
+++ b/src/features/Instructors/InstructorsPage/_test_/index.test.jsx
@@ -99,11 +99,11 @@ describe('InstructorPage', () => {
 
     waitFor(() => {
       expect(component.container).toHaveTextContent('Instructor1');
-      expect(component.container).toHaveTextContent('Instructor2');
       expect(component.container).toHaveTextContent('Instructor 1');
-      expect(component.container).toHaveTextContent('Instructor 2');
       expect(component.container).toHaveTextContent('instructor1@example.com');
-      expect(component.container).toHaveTextContent('instructor2@example.com');
+      expect(component.container).not.toHaveTextContent('Instructor2');
+      expect(component.container).not.toHaveTextContent('Instructor 2');
+      expect(component.container).not.toHaveTextContent('instructor2@example.com');
     });
   });
 

--- a/src/features/Instructors/InstructorsPage/index.jsx
+++ b/src/features/Instructors/InstructorsPage/index.jsx
@@ -9,7 +9,6 @@ import StatusFilters from 'features/Instructors/StatusFilters';
 import { Button } from 'react-paragon-topaz';
 
 import { updateCurrentPage, updateFilters, resetInstructorsRequest } from 'features/Instructors/data/slice';
-import { fetchInstructorsData } from 'features/Instructors/data/thunks';
 import { initialPage, INSTRUCTOR_STATUS_TABS } from 'features/constants';
 
 const InstructorsPage = () => {
@@ -17,19 +16,17 @@ const InstructorsPage = () => {
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const dispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [statusFilter, setStatusFilter] = useState(INSTRUCTOR_STATUS_TABS.ALL);
+  const [statusFilter, setStatusFilter] = useState(INSTRUCTOR_STATUS_TABS.ACTIVE);
   const [isOpen, openModal, closeModal] = useToggle(false);
 
   useEffect(() => {
-    if (Object.keys(selectedInstitution).length > 0) {
-      dispatch(fetchInstructorsData(selectedInstitution.id, currentPage));
-    }
+    if (Object.keys(selectedInstitution).length === 0) { return undefined; }
 
     return () => {
       dispatch(resetInstructorsRequest());
       dispatch(updateFilters({}));
     };
-  }, [selectedInstitution, dispatch, currentPage]);
+  }, [selectedInstitution, dispatch]);
 
   const handlePagination = (targetPage) => {
     setCurrentPage(targetPage);
@@ -41,7 +38,7 @@ const InstructorsPage = () => {
   };
 
   const handleResetFilters = () => {
-    setStatusFilter(INSTRUCTOR_STATUS_TABS.ALL);
+    setStatusFilter(INSTRUCTOR_STATUS_TABS.ACTIVE);
   };
 
   return (

--- a/src/features/Instructors/StatusFilters/index.jsx
+++ b/src/features/Instructors/StatusFilters/index.jsx
@@ -39,7 +39,7 @@ const StatusFilters = ({ currentPage, statusFilter, setStatusFilter }) => {
 
   return (
     <Tabs
-      defaultActiveKey="All"
+      defaultActiveKey="Active"
       activeKey={statusFilter}
       onSelect={setStatusFilter}
       variant="button-group"


### PR DESCRIPTION
# Description

Changed the default tab filter on the Instructors page (admin/institutions view) from **All** to **Active**, so only active instructors are shown on initial load. 

## Ticket
https://pearson.atlassian.net/browse/PADV-3502

### Changes

**`InstructorsPage/index.jsx`**
- Set initial `statusFilter` state to `INSTRUCTOR_STATUS_TABS.ACTIVE` instead of `INSTRUCTOR_STATUS_TABS.ALL`.
- Updated `handleResetFilters` to reset back to `ACTIVE` instead of `ALL`.
- Removed the redundant `fetchInstructorsData` call from the page-level `useEffect`. `StatusFilters` already owns all data fetching based on the active tab — having both effects caused a race condition where the unfiltered parent fetch (running after the child's filtered fetch) overwrote the results, showing all instructors regardless of the selected tab.
- Removed the now-unused `fetchInstructorsData` import.

**`StatusFilters/index.jsx`**
- Changed `defaultActiveKey` from `"All"` to `"Active"` so the Paragon `Tabs` component visually reflects the correct initial selection.

**`InstructorsPage/_test_/index.test.jsx`**
- Updated the initial render assertion to expect only the active instructor (`Instructor1`) and assert that the inactive instructor (`Instructor2`) is not present, reflecting the new default behavior.


