### PR TITLE
feat: add 'Last access date' column to Classes and Students tables

### DIFF
--- a/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
@@ -60,12 +60,13 @@ describe('getColumns', () => {
     const columns = getColumns({ enableVoucherColumn: true });
 
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(10);
+    expect(columns).toHaveLength(11);
 
     const [
       number,
       student,
       learnerEmail,
+      lastAccessDate,
       status,
       voucherStatus,
       completePercentage,
@@ -78,6 +79,7 @@ describe('getColumns', () => {
     expect(number).toHaveProperty('Header', 'No');
     expect(student).toHaveProperty('Header', 'Student');
     expect(learnerEmail).toHaveProperty('Header', 'Email');
+    expect(lastAccessDate).toHaveProperty('Header', 'Last access date');
     expect(status).toHaveProperty('Header', 'Status');
     expect(voucherStatus).toHaveProperty('Header', 'Voucher Status');
     expect(completePercentage).toHaveProperty('Header', 'Current Grade');
@@ -116,7 +118,7 @@ describe('getColumns', () => {
   test('renders Status badge', () => {
     const columns = getColumns();
 
-    const StatusColumn = () => columns[3].Cell({
+    const StatusColumn = () => columns[4].Cell({
       row: { values: { status: 'Active' } },
     });
 
@@ -131,7 +133,7 @@ describe('getColumns', () => {
   test('renders Current Grade with safe value', () => {
     const columns = getColumns();
 
-    const GradeColumn = () => columns[4].Cell({
+    const GradeColumn = () => columns[5].Cell({
       row: { values: { completePercentage: 25.8 } },
     });
 
@@ -146,7 +148,7 @@ describe('getColumns', () => {
   test('renders Exam Ready ProgressSteps', () => {
     const columns = getColumns();
 
-    const ExamColumn = () => columns[5].Cell({
+    const ExamColumn = () => columns[6].Cell({
       row: {
         values: {
           examReady: { status: 'NOT_STARTED' },
@@ -165,7 +167,7 @@ describe('getColumns', () => {
   test('renders Last exam date as -- when null', () => {
     const columns = getColumns();
 
-    const LastExamColumn = () => columns[6].Cell({
+    const LastExamColumn = () => columns[7].Cell({
       row: {
         values: {
           examReady: { lastExamDate: null },
@@ -184,7 +186,7 @@ describe('getColumns', () => {
   test('renders Epp Days Left when value exists', () => {
     const columns = getColumns();
 
-    const EppDaysColumn = () => columns[7].Cell({
+    const EppDaysColumn = () => columns[8].Cell({
       row: { values: { examReady: { eppDaysLeft: 3 } } },
     });
 
@@ -199,7 +201,7 @@ describe('getColumns', () => {
   test('renders Epp Days Left as -- when null', () => {
     const columns = getColumns();
 
-    const EppDaysColumn = () => columns[7].Cell({
+    const EppDaysColumn = () => columns[8].Cell({
       row: { values: { examReady: { eppDaysLeft: null } } },
     });
 
@@ -214,7 +216,7 @@ describe('getColumns', () => {
   test('renders Actions dropdown', () => {
     const columns = getColumns();
 
-    const ActionColumn = () => columns[8].Cell({
+    const ActionColumn = () => columns[9].Cell({
       row: {
         values: { classId: 'CCX1' },
         original: {
@@ -241,7 +243,7 @@ describe('getColumns', () => {
   test('renders Voucher option only when displayVoucherOptions = true', () => {
     const columns = getColumns({ displayVoucherOptions: true });
 
-    const ActionColumn = () => columns[8].Cell({
+    const ActionColumn = () => columns[9].Cell({
       row: {
         values: { classId: 'CCX1' },
         original: {
@@ -271,7 +273,7 @@ describe('getColumns', () => {
   test('does NOT render Voucher option when displayVoucherOptions = false', () => {
     const columns = getColumns();
 
-    const ActionColumn = () => columns[8].Cell({
+    const ActionColumn = () => columns[9].Cell({
       row: {
         values: { classId: 'CCX1' },
         original: {

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -54,6 +54,16 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
     ),
   },
   {
+    Header: 'Last access date',
+    accessor: 'lastAccess',
+    Cell: ({ row }) => {
+      const lastAccess = row.original.lastAccess
+        ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
+        : '--';
+      return <span>{lastAccess}</span>;
+    },
+  },
+  {
     Header: 'Status',
     accessor: 'status',
     Cell: ({ row }) => (

--- a/src/features/Students/StudentsPage/_test_/index.test.jsx
+++ b/src/features/Students/StudentsPage/_test_/index.test.jsx
@@ -21,7 +21,7 @@ const mockStore = {
           instructors: ['Instructor 1'],
           created: 'Fri, 25 Aug 2023 19:01:22 GMT',
           firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
-          lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
+          lastAccess: '2023-08-25T20:20:22Z',
           status: 'Active',
           examReady: {
             status: 'READY',
@@ -37,7 +37,7 @@ const mockStore = {
           instructors: ['Instructor 2'],
           created: 'Sat, 26 Aug 2023 19:01:22 GMT',
           firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
-          lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
+          lastAccess: '2023-08-26T21:22:22Z',
           status: 'Pending',
           examReady: {
             status: 'PENDING',

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -45,11 +45,12 @@ describe('StudentsTable Columns', () => {
 
   test('returns an array of columns with correct properties', () => {
     expect(columns).toBeInstanceOf(Array);
-    expect(columns).toHaveLength(10);
+    expect(columns).toHaveLength(11);
 
     const [
       studentCol,
       emailCol,
+      lastAccessDateCol,
       statusCol,
       classNameCol,
       dateCol,
@@ -65,6 +66,9 @@ describe('StudentsTable Columns', () => {
 
     expect(emailCol).toHaveProperty('Header', 'Email');
     expect(emailCol).toHaveProperty('accessor', 'learnerEmail');
+
+    expect(lastAccessDateCol).toHaveProperty('Header', 'Last access date');
+    expect(lastAccessDateCol).toHaveProperty('accessor', 'lastAccess');
 
     expect(statusCol).toHaveProperty('Header', 'Status');
     expect(statusCol).toHaveProperty('accessor', 'status');
@@ -91,7 +95,7 @@ describe('StudentsTable Columns', () => {
   });
 
   test('renders dropdown menu correctly', async () => {
-    const ActionColumn = () => columns[9].Cell({
+    const ActionColumn = () => columns[10].Cell({
       row: {
         values: {
           classId: 'CCX1',
@@ -120,7 +124,7 @@ describe('StudentsTable Columns', () => {
   });
 
   test('renders EPP Days Left cell with correct value', () => {
-    const EppDaysColumn = columns[8];
+    const EppDaysColumn = columns[9];
     const CellComponent = () => EppDaysColumn.Cell({
       row: {
         values: {
@@ -138,7 +142,7 @@ describe('StudentsTable Columns', () => {
   });
 
   test('renders EPP Days Left cell as "--" when null', () => {
-    const EppDaysColumn = columns[8];
+    const EppDaysColumn = columns[9];
     const CellComponent = () => EppDaysColumn.Cell({
       row: {
         values: {

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -48,6 +48,16 @@ const columns = [
     ),
   },
   {
+    Header: 'Last access date',
+    accessor: 'lastAccess',
+    Cell: ({ row }) => {
+      const lastAccess = row.original.lastAccess
+        ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
+        : '--';
+      return <span>{lastAccess}</span>;
+    },
+  },
+  {
     Header: 'Status',
     accessor: 'status',
     Cell: ({ row }) => (


### PR DESCRIPTION
# Description
Adds a new "Last access date" column to both the Class Details and Students tables in the admin portal. The column is rendered immediately after the "Email" column and displays the student's last platform access date, sourced from the `last_access` field returned by the API.

## Ticket
https://pearson.atlassian.net/browse/PADV-3504

**Changes**

- `features/Classes/Class/ClassPage/columns.jsx` — Added `Last access date` column (accessor: `last_access`) after the `Email` column, formatted with `formatUTCDate('MM/dd/yy')` and displaying `--` when the value is absent.
- `features/Students/StudentsTable/columns.jsx` — Same column added in the same position with identical formatting logic.

