### PR TITLE
PADV-3481 - Retain class search results after an action on a class.

### DIFF
--- a/src/features/Classes/Class/ClassPage/Actions.jsx
+++ b/src/features/Classes/Class/ClassPage/Actions.jsx
@@ -24,7 +24,8 @@ import EnrollStudent from 'features/Classes/EnrollStudent';
 
 import { resetClassState } from 'features/Courses/data/slice';
 import { deleteClass } from 'features/Courses/data/thunks';
-import { fetchAllClassesData, fetchLabSummaryLink } from 'features/Classes/data/thunks';
+import { fetchLabSummaryLink } from 'features/Classes/data/thunks';
+import { classesApi, useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
 
 const initialDeletionClassState = {
   isModalOpen: false,
@@ -37,7 +38,6 @@ const Actions = ({ previousPage }) => {
   const { courseId, classId } = useParams();
   const courseIdDecoded = decodeURIComponent(courseId);
   const classIdDecoded = decodeURIComponent(classId);
-  const classes = useSelector((state) => state.classes.allClasses.data);
   const deletionState = useSelector((state) => state.courses.newClass.status);
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const gradebookUrl = getConfig().GRADEBOOK_MICROFRONTEND_URL || getConfig().LMS_BASE_URL;
@@ -51,6 +51,11 @@ const Actions = ({ previousPage }) => {
   const [deletionClassState, setDeletionState] = useState(initialDeletionClassState);
 
   const classLink = `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classIdDecoded}/home`;
+
+  const { data: classes = [] } = useGetClassesByCourseQuery(
+    { institutionId: selectedInstitution.id, courseId: courseIdDecoded },
+    { skip: !selectedInstitution.id },
+  );
 
   const [classInfo] = classes.filter(
     (classElement) => classElement.classId === classIdDecoded,
@@ -116,7 +121,7 @@ const Actions = ({ previousPage }) => {
   };
 
   const finalCall = () => {
-    dispatch(fetchAllClassesData(selectedInstitution.id, courseIdDecoded));
+    dispatch(classesApi.util.invalidateTags(['Classes']));
   };
 
   return (

--- a/src/features/Classes/Class/ClassPage/index.jsx
+++ b/src/features/Classes/Class/ClassPage/index.jsx
@@ -17,18 +17,16 @@ import { Button } from 'react-paragon-topaz';
 
 import { updateActiveTab } from 'features/Main/data/slice';
 import { getColumns } from 'features/Classes/Class/ClassPage/columns';
-import { resetStudentsTable, updateCurrentPage } from 'features/Students/data/slice';
-import { fetchStudentsData, fetchStudentsVouchers } from 'features/Students/data';
+import { fetchStudentsVouchers } from 'features/Students/data';
 
 import {
   initialPage,
-  RequestStatus,
   VOUCHER_STATUS,
   VOUCHER_RULE_TYPES,
   VOUCHER_RULES,
 } from 'features/constants';
-import { resetClassesTable, resetClasses } from 'features/Classes/data/slice';
-import { fetchAllClassesData } from 'features/Classes/data/thunks';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetStudentsByClassQuery } from 'features/Students/data/studentsApi';
 
 import { useInstitutionIdQueryParam } from 'hooks';
 
@@ -47,24 +45,44 @@ const ClassPage = () => {
   const institutionRef = useRef(undefined);
   const [currentPage, setCurrentPage] = useState(initialPage);
   const institution = useSelector((state) => state.main.selectedInstitution);
-  const students = useSelector((state) => state.students.table);
   const vouchers = useSelector((state) => state.students.vouchers?.results || []);
   const addQueryParam = useInstitutionIdQueryParam();
-
-  const isLoadingStudents = students.status === RequestStatus.LOADING;
 
   const enableVoucherColumn = getConfig().PSS_ENABLE_ASSIGN_VOUCHER || false;
 
   const handlePagination = (targetPage) => {
     setCurrentPage(targetPage);
-    dispatch(updateCurrentPage(targetPage));
   };
 
   const defaultClassInfo = useMemo(() => ({
     className: '',
   }), []);
 
-  const classInfo = useSelector((state) => state.classes.allClasses.data)
+  const { data: classesByCourse = [] } = useGetClassesByCourseQuery(
+    { institutionId: institution.id, courseId: courseIdDecoded },
+    { skip: !institution.id },
+  );
+
+  const {
+    data: studentsData = {},
+    isFetching: isLoadingStudents,
+  } = useGetStudentsByClassQuery(
+    {
+      institutionId: institution.id,
+      page: currentPage,
+      courseId: courseIdDecoded,
+      classId: classIdDecoded,
+    },
+    { skip: !institution.id },
+  );
+
+  const {
+    results: studentsList = [],
+    count: studentsCount = 0,
+    numPages: studentsNumPages = 0,
+  } = studentsData;
+
+  const classInfo = classesByCourse
     .find((classElement) => classElement?.classId === classIdDecoded) || defaultClassInfo;
 
   const displayVoucherOptions = classInfo.examSeriesCode;
@@ -134,25 +152,25 @@ const ClassPage = () => {
   };
 
   const mergeStudentsWithVouchers = () => {
-    if (!students?.data?.length) {
+    if (!studentsList?.length) {
       return [];
     }
 
     if (!vouchers?.length) {
-      return students.data.map(student => ({
+      return studentsList.map(student => ({
         ...student,
         voucherInfo: createVoucherInfo(null, VOUCHER_RULE_TYPES.NO_VOUCHER),
       }));
     }
 
     if (!institution?.uuid) {
-      return students.data.map(student => ({
+      return studentsList.map(student => ({
         ...student,
         voucherInfo: createVoucherInfo(null, VOUCHER_RULE_TYPES.DEFAULT),
       }));
     }
 
-    return students.data.map(student => {
+    return studentsList.map(student => {
       const { sameInstitution, otherInstitution } = groupUserVouchersByInstitution(
         vouchers,
         student.userId,
@@ -187,38 +205,10 @@ const ClassPage = () => {
   }, [dispatch, classIdDecoded]);
 
   useEffect(() => {
-    if (institution.id) {
-      const params = {
-        course_id: courseIdDecoded,
-        class_id: classIdDecoded,
-        limit: true,
-      };
-
-      dispatch(fetchStudentsData(institution.id, currentPage, params));
-    }
-
-    return () => {
-      dispatch(resetStudentsTable());
-      dispatch(updateCurrentPage(initialPage));
-    };
-  }, [dispatch, institution.id, courseIdDecoded, classIdDecoded, currentPage]);
-
-  useEffect(() => {
     if (institution.id && displayVoucherOptions) {
       dispatch(fetchStudentsVouchers(displayVoucherOptions));
     }
   }, [dispatch, institution.id, displayVoucherOptions]);
-
-  useEffect(() => {
-    if (institution.id) {
-      dispatch(fetchAllClassesData(institution.id, courseIdDecoded));
-    }
-
-    return () => {
-      dispatch(resetClassesTable());
-      dispatch(resetClasses());
-    };
-  }, [dispatch, institution.id, courseIdDecoded]);
 
   useEffect(() => {
     if (institution.id !== undefined && institutionRef.current === undefined) {
@@ -253,14 +243,14 @@ const ClassPage = () => {
           <Table
             isLoading={isLoadingStudents}
             columns={COLUMNS}
-            count={students.count}
+            count={studentsCount}
             data={mergeStudentsWithVouchers()}
             text="No students were found for this class."
           />
-          {students.numPages > 1 && (
+          {studentsNumPages > 1 && (
           <Pagination
             paginationLabel="paginationNavigation"
-            pageCount={students.numPages}
+            pageCount={studentsNumPages}
             currentPage={currentPage}
             onPageSelect={handlePagination}
             variant="reduced"

--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -8,11 +8,23 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { renderWithProviders } from 'test-utils';
 
 import ClassesFilters from 'features/Classes/ClassesFilters';
+import { useGetCoursesOptionsQuery } from 'features/Courses/data/coursesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(() => ({})),
   useLocation: jest.fn(() => ({})),
+}));
+
+jest.mock('features/Courses/data/coursesApi', () => ({
+  ...jest.requireActual('features/Courses/data/coursesApi'),
+  useGetCoursesOptionsQuery: jest.fn(),
+}));
+
+jest.mock('features/Instructors/data/instructorsApi', () => ({
+  ...jest.requireActual('features/Instructors/data/instructorsApi'),
+  useGetInstructorsOptionsQuery: jest.fn(),
 }));
 
 let axiosMock;
@@ -96,8 +108,9 @@ jest.mock('react-paragon-topaz', () => ({
       ))}
     </select>
   ),
-  Button: ({ children, ...props }) => (
-    <button {...props} type="button">
+  Button: ({ children, type = 'button', ...props }) => (
+    // eslint-disable-next-line react/button-has-type
+    <button {...props} type={type}>
       {children}
     </button>
   ),
@@ -118,6 +131,15 @@ describe('ClassesFilters Component', () => {
 
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
     mockSetFilters.mockClear();
+
+    useGetCoursesOptionsQuery.mockReturnValue({
+      data: [courseOption],
+      isFetching: false,
+    });
+    useGetInstructorsOptionsQuery.mockReturnValue({
+      data: [instructorOption],
+      isFetching: false,
+    });
 
     const coursesApiUrl = `
     ${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/courses/?limit=false&institution_id=1&page=1`;
@@ -258,5 +280,78 @@ describe('ClassesFilters Component', () => {
     });
 
     expect(buttonApply).toBeInTheDocument();
+  });
+
+  test('Should restore previously applied filter values from state', () => {
+    const resetPagination = jest.fn();
+    const preloadedState = {
+      ...mockStore,
+      classes: {
+        filtersForm: {
+          classFilter: 'Persisted class',
+          courseSelected: null,
+          instructorSelected: null,
+          startDate: '2024-01-01',
+          endDate: '2024-02-01',
+        },
+      },
+    };
+
+    const { getByTestId } = renderWithProviders(
+      <ClassesFilters resetPagination={resetPagination} />,
+      { preloadedState },
+    );
+
+    expect(getByTestId('class_name')).toHaveValue('Persisted class');
+    expect(getByTestId('start_date')).toHaveValue('2024-01-01');
+    expect(getByTestId('end_date')).toHaveValue('2024-02-01');
+  });
+
+  test('Should persist filter form values in state when applying', async () => {
+    const resetPagination = jest.fn();
+    const { getByText, getByTestId, store } = renderWithProviders(
+      <ClassesFilters resetPagination={resetPagination} />,
+      { preloadedState: mockStore },
+    );
+
+    fireEvent.change(getByTestId('class_name'), {
+      target: { value: 'My class' },
+    });
+
+    await act(async () => {
+      fireEvent.click(getByText('Apply'));
+    });
+
+    expect(store.getState().classes.filtersForm.classFilter).toBe('My class');
+  });
+
+  test('Should reset the persisted filter form when cleaning filters', async () => {
+    const resetPagination = jest.fn();
+    const preloadedState = {
+      ...mockStore,
+      classes: {
+        filtersForm: {
+          classFilter: 'Persisted class',
+          courseSelected: null,
+          instructorSelected: null,
+          startDate: '',
+          endDate: '',
+        },
+      },
+    };
+
+    const { getByText, getByTestId, store } = renderWithProviders(
+      <ClassesFilters resetPagination={resetPagination} />,
+      { preloadedState },
+    );
+
+    expect(getByTestId('class_name')).toHaveValue('Persisted class');
+
+    await act(async () => {
+      fireEvent.click(getByText('Reset'));
+    });
+
+    expect(store.getState().classes.filtersForm).toEqual({});
+    expect(getByTestId('class_name')).toHaveValue('');
   });
 });

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -5,19 +5,26 @@ import PropTypes from 'prop-types';
 
 import { Col, Form } from '@openedx/paragon';
 import { Select, Button } from 'react-paragon-topaz';
-import { logError } from '@edx/frontend-platform/logging';
 
 import { initialPage } from 'features/constants';
 import { buildFilterParams } from 'helpers';
-import { fetchClassesData } from 'features/Classes/data/thunks';
-import { fetchCoursesOptionsData } from 'features/Courses/data/thunks';
-import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
-import { updateFilters, updateCurrentPage } from 'features/Classes/data/slice';
+import { useGetCoursesOptionsQuery } from 'features/Courses/data/coursesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
+import {
+  updateFilters,
+  updateFiltersForm,
+  resetFiltersForm,
+  updateCurrentPage,
+} from 'features/Classes/data/slice';
 
 const NOT_ASSIGNED_OPTION = {
   label: 'Not assigned',
   value: 'null',
 };
+
+// Stable empty array reference to avoid re-triggering effects while the
+// cached queries are loading (a new [] on every render would cause a loop).
+const EMPTY_OPTIONS = [];
 
 const getInitialFilters = () => ({
   classFilter: '',
@@ -33,13 +40,24 @@ const ClassesFilters = ({ resetPagination }) => {
   const firstRenderPage = useRef(false);
 
   const institution = useSelector((state) => state.main.selectedInstitution);
-  const courses = useSelector((state) => state.courses.selectOptions);
-  const instructors = useSelector((state) => state.instructors.selectOptions.data);
+  const persistedFiltersForm = useSelector((state) => state.classes.filtersForm);
+
+  const { data: courses = EMPTY_OPTIONS, isLoading: isLoadingCourses } = useGetCoursesOptionsQuery(
+    { institutionId: institution.id },
+    { skip: !institution.id },
+  );
+  const { data: instructors = EMPTY_OPTIONS, isLoading: isLoadingInstructors } = useGetInstructorsOptionsQuery(
+    { institutionId: institution.id, filters: { limit: false } },
+    { skip: !institution.id },
+  );
 
   const queryParams = new URLSearchParams(location.search);
   const queryNotInstructors = queryParams.get('instructors');
 
-  const [filters, setFilters] = useState(getInitialFilters);
+  const [filters, setFilters] = useState(() => ({
+    ...getInitialFilters(),
+    ...persistedFiltersForm,
+  }));
   const [courseOptions, setCourseOptions] = useState([]);
   const [instructorOptions, setInstructorOptions] = useState([NOT_ASSIGNED_OPTION]);
 
@@ -69,15 +87,13 @@ const ClassesFilters = ({ resetPagination }) => {
     }
   }, [queryNotInstructors]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSelectFilters = async (e) => {
+  const handleSelectFilters = (e) => {
     e.preventDefault();
 
     if (isButtonDisabled) { return; }
 
     const nullInstructor = instructorSelected?.value === 'null';
     const notSelectedInstructor = instructorSelected?.value ?? null;
-    const formData = new FormData(e.target);
-    const courseName = formData.get('course_name');
 
     const formJson = buildFilterParams({
       instructor: nullInstructor ? null : notSelectedInstructor,
@@ -87,17 +103,18 @@ const ClassesFilters = ({ resetPagination }) => {
       end_date: endDate,
     });
 
-    try {
-      dispatch(updateFilters(formJson));
-      dispatch(updateCurrentPage(initialPage));
-      dispatch(fetchClassesData(institution.id, initialPage, courseName, formJson));
-    } catch (error) {
-      logError(error);
-    }
+    const appliedFilters = courseSelected?.value
+      ? { ...formJson, courseId: courseSelected.value }
+      : formJson;
+
+    dispatch(updateFilters(appliedFilters));
+    dispatch(updateFiltersForm(filters));
+    dispatch(updateCurrentPage(initialPage));
   };
 
   const handleCleanFilters = () => {
-    dispatch(fetchClassesData(institution.id, initialPage));
+    dispatch(updateFilters({}));
+    dispatch(resetFiltersForm());
     resetPagination();
     setFilters(getInitialFilters());
   };
@@ -126,15 +143,10 @@ const ClassesFilters = ({ resetPagination }) => {
       setFilters((prev) => ({ ...prev, courseSelected: null, instructorSelected: null }));
     }
 
-    if (Object.keys(institution).length > 0) {
-      dispatch(fetchCoursesOptionsData(institution.id));
-      dispatch(fetchInstructorsOptionsData(institution.id, initialPage, { limit: false }));
-    }
-
     if (queryNotInstructors === 'null') {
       firstRenderPage.current = true;
     }
-  }, [institution, dispatch, queryNotInstructors]);
+  }, [institution, queryNotInstructors]);
 
   return (
     <Form onSubmit={handleSelectFilters} className="w-100 px-4 d-flex flex-column align-items-center">
@@ -184,6 +196,8 @@ const ClassesFilters = ({ resetPagination }) => {
             options={courseOptions}
             onChange={(option) => updateFilter('courseSelected', option)}
             value={courseSelected}
+            isLoading={isLoadingCourses}
+            isDisabled={isLoadingCourses}
           />
         </Form.Group>
         <Form.Group as={Col} className="px-0 w-50">
@@ -193,6 +207,8 @@ const ClassesFilters = ({ resetPagination }) => {
             options={instructorOptions}
             onChange={(option) => updateFilter('instructorSelected', option)}
             value={instructorSelected}
+            isLoading={isLoadingInstructors}
+            isDisabled={isLoadingInstructors}
           />
         </Form.Group>
       </Form.Row>

--- a/src/features/Classes/ClassesPage/index.jsx
+++ b/src/features/Classes/ClassesPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Container, Pagination } from '@openedx/paragon';
 import { useLocation } from 'react-router-dom';
@@ -6,46 +6,41 @@ import { useLocation } from 'react-router-dom';
 import ClassesTable from 'features/Classes/ClassesTable';
 import ClassesFilters from 'features/Classes/ClassesFilters';
 
-import { updateCurrentPage, updateFilters, resetClassesTable } from 'features/Classes/data/slice';
-import { fetchClassesData } from 'features/Classes/data/thunks';
+import { updateCurrentPage } from 'features/Classes/data/slice';
+import { useGetClassesQuery } from 'features/Classes/data/classesApi';
 import { initialPage } from 'features/constants';
 
 const ClassesPage = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
-  const stateClasses = useSelector((state) => state.classes);
-  const [currentPage, setCurrentPage] = useState(initialPage);
+  const storedFilters = useSelector((state) => state.classes.filters);
+  const currentPage = useSelector((state) => state.classes.table.currentPage) || initialPage;
   const resetFiltersRef = useRef(false);
 
   const queryParams = new URLSearchParams(location.search);
   const queryNotInstructors = queryParams.get('instructors');
-  const instructorsNull = { instructors: queryNotInstructors };
 
-  useEffect(() => {
-    if (Object.keys(selectedInstitution).length > 0) {
-      if (queryNotInstructors === 'null' && !resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', instructorsNull));
-      } else if (queryNotInstructors === 'null' && resetFiltersRef.current) {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
-      } else {
-        dispatch(fetchClassesData(selectedInstitution.id, currentPage, '', stateClasses.filters));
-      }
-    }
+  const isForcedInstructorsView = queryNotInstructors === 'null' && !resetFiltersRef.current;
+  const filters = isForcedInstructorsView ? { instructors: queryNotInstructors } : storedFilters;
 
-    return () => {
-      dispatch(resetClassesTable());
-      dispatch(updateFilters({}));
-    };
-  }, [selectedInstitution, dispatch, currentPage]); // eslint-disable-line react-hooks/exhaustive-deps
+  const institutionId = selectedInstitution?.id;
+
+  const { data, isFetching } = useGetClassesQuery(
+    { institutionId, page: currentPage, filters },
+    { skip: !institutionId },
+  );
+
+  const classes = data?.results || [];
+  const count = data?.count || 0;
+  const numPages = data?.numPages || 0;
 
   const handlePagination = (targetPage) => {
-    setCurrentPage(targetPage);
     dispatch(updateCurrentPage(targetPage));
   };
 
   const resetPagination = () => {
-    setCurrentPage(initialPage);
+    dispatch(updateCurrentPage(initialPage));
     resetFiltersRef.current = true;
   };
 
@@ -55,13 +50,14 @@ const ClassesPage = () => {
       <div className="page-content-container">
         <ClassesFilters resetPagination={resetPagination} />
         <ClassesTable
-          data={stateClasses.table.data}
-          count={stateClasses.table.count}
+          data={classes}
+          count={count}
+          isLoading={isFetching}
         />
-        {stateClasses.table.numPages > 1 && (
+        {numPages > 1 && (
           <Pagination
             paginationLabel="paginationNavigation"
-            pageCount={stateClasses.table.numPages}
+            pageCount={numPages}
             currentPage={currentPage}
             onPageSelect={handlePagination}
             variant="reduced"

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -19,10 +19,11 @@ import DeleteModal from 'features/Common/DeleteModal';
 import LinkWithQuery from 'features/Main/LinkWithQuery';
 import EnrollStudent from 'features/Classes/EnrollStudent';
 
-import { RequestStatus, initialPage, modalDeleteText } from 'features/constants';
+import { RequestStatus, modalDeleteText } from 'features/constants';
 
 import { deleteClass } from 'features/Courses/data/thunks';
-import { fetchClassesData, fetchLabSummaryLink, supersetUrlClassesDashboard } from 'features/Classes/data/thunks';
+import { fetchLabSummaryLink, supersetUrlClassesDashboard } from 'features/Classes/data/thunks';
+import { classesApi } from 'features/Classes/data/classesApi';
 
 import { formatUTCDate, setAssignStaffRole } from 'helpers';
 import { resetClassState } from 'features/Courses/data/slice';
@@ -127,7 +128,6 @@ const columns = [
       };
 
       const dispatch = useDispatch();
-      const institution = useSelector((state) => state.main.selectedInstitution);
       const deletionState = useSelector((state) => state.courses.newClass.status);
       const [isOpenModal, openModal, closeModal] = useToggle(false);
       const [isOpenEnrollModal, openEnrollModal, closeEnrollModal] = useToggle(false);
@@ -162,7 +162,7 @@ const columns = [
             isRequestComplete: true,
           });
 
-          await dispatch(fetchClassesData(institution.id, initialPage));
+          dispatch(classesApi.util.invalidateTags(['Classes']));
         } catch (error) {
           logError(error);
         } finally {
@@ -202,7 +202,7 @@ const columns = [
       };
 
       const finalCall = () => {
-        dispatch(fetchClassesData(institution.id, initialPage));
+        dispatch(classesApi.util.invalidateTags(['Classes']));
       };
 
       return (

--- a/src/features/Classes/ClassesTable/index.jsx
+++ b/src/features/Classes/ClassesTable/index.jsx
@@ -1,15 +1,11 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Row, Col } from '@openedx/paragon';
 import { columns } from 'features/Classes/ClassesTable/columns';
-import { RequestStatus } from 'features/constants';
 import Table from 'features/Main/Table';
 
-const ClassesTable = ({ data, count }) => {
-  const classesRequest = useSelector((state) => state.classes.table.status);
+const ClassesTable = ({ data, count, isLoading }) => {
   const COLUMNS = useMemo(() => columns, []);
-  const isLoading = classesRequest === RequestStatus.LOADING;
 
   return (
     <Row className="justify-content-center my-4 my-3 mx-0">
@@ -30,11 +26,13 @@ const ClassesTable = ({ data, count }) => {
 ClassesTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
   count: PropTypes.number,
+  isLoading: PropTypes.bool,
 };
 
 ClassesTable.defaultProps = {
   data: [],
   count: 0,
+  isLoading: false,
 };
 
 export default ClassesTable;

--- a/src/features/Classes/EnrollStudent/__test__/index.test.jsx
+++ b/src/features/Classes/EnrollStudent/__test__/index.test.jsx
@@ -3,6 +3,7 @@ import { renderWithProviders } from 'test-utils';
 import { fireEvent, waitFor } from '@testing-library/react';
 
 import EnrollStudent from 'features/Classes/EnrollStudent';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
 
 import * as api from 'features/Students/data/api';
 
@@ -14,6 +15,11 @@ jest.mock('react-router-dom', () => ({
 jest.mock('features/Students/data/api', () => ({
   handleEnrollments: jest.fn().mockReturnValue({}),
   getMessages: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('features/Classes/data/classesApi', () => ({
+  ...jest.requireActual('features/Classes/data/classesApi'),
+  useGetClassesByCourseQuery: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -34,6 +40,13 @@ const mockStore = {
 };
 
 describe('EnrollStudent', () => {
+  beforeEach(() => {
+    useGetClassesByCourseQuery.mockReturnValue({
+      data: mockStore.classes.allClasses.data,
+      isFetching: false,
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/src/features/Classes/EnrollStudent/index.jsx
+++ b/src/features/Classes/EnrollStudent/index.jsx
@@ -14,10 +14,9 @@ import {
 import { Button } from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { fetchStudentsData } from 'features/Students/data';
 import { handleEnrollments, getMessages } from 'features/Students/data/api';
-import { fetchAllClassesData } from 'features/Classes/data/thunks';
-import { initialPage } from 'features/constants';
+import { studentsApi } from 'features/Students/data/studentsApi';
+import { classesApi, useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
 
 import 'features/Classes/EnrollStudent/index.scss';
 
@@ -41,7 +40,12 @@ const EnrollStudent = ({
     className: '',
   }), []);
 
-  const classInfo = useSelector((state) => state.classes.allClasses.data)
+  const { data: classesByCourse = [] } = useGetClassesByCourseQuery(
+    { institutionId: institution.id, courseId: courseIdDecoded },
+    { skip: !institution.id || !courseId },
+  );
+
+  const classInfo = classesByCourse
     .find((classElement) => classElement?.classId === classIdDecoded) || defaultClassInfo;
 
   const handleEnrollStudent = async (e) => {
@@ -96,16 +100,9 @@ const EnrollStudent = ({
 
       setToastMessage(textToast);
 
-      const params = {
-        course_id: courseIdDecoded,
-        class_id: customClassId || classIdDecoded,
-        limit: true,
-      };
+      dispatch(studentsApi.util.invalidateTags(['StudentsClass']));
 
-      dispatch(fetchStudentsData(institution.id, initialPage, params));
-
-      // Get the classes info updated with the new number of students enrolled.
-      dispatch(fetchAllClassesData(institution.id, courseIdDecoded));
+      dispatch(classesApi.util.invalidateTags(['Classes']));
 
       setShowToast(true);
       return onClose();

--- a/src/features/Classes/InstructorCard/__test__/analyticsSlot.test.jsx
+++ b/src/features/Classes/InstructorCard/__test__/analyticsSlot.test.jsx
@@ -3,9 +3,21 @@ import { Route } from 'react-router-dom';
 import { renderWithProviders } from 'test-utils';
 
 import InstructorCard from 'features/Classes/InstructorCard';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
+}));
+
+jest.mock('features/Classes/data/classesApi', () => ({
+  ...jest.requireActual('features/Classes/data/classesApi'),
+  useGetClassesByCourseQuery: jest.fn(),
+}));
+
+jest.mock('features/Instructors/data/instructorsApi', () => ({
+  ...jest.requireActual('features/Instructors/data/instructorsApi'),
+  useGetInstructorsOptionsQuery: jest.fn(),
 }));
 
 const basePath = `/courses/${encodeURIComponent(
@@ -40,6 +52,18 @@ const stateMock = {
 };
 
 describe('InstructorCard analytics slot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useGetClassesByCourseQuery.mockReturnValue({
+      data: stateMock.classes.allClasses.data,
+      isFetching: false,
+    });
+    useGetInstructorsOptionsQuery.mockReturnValue({
+      data: stateMock.instructors.selectOptions.data,
+      isFetching: false,
+    });
+  });
+
   test('renders children inside the class details card', () => {
     const { getByText } = renderWithProviders(
       <Route

--- a/src/features/Classes/InstructorCard/__test__/index.test.jsx
+++ b/src/features/Classes/InstructorCard/__test__/index.test.jsx
@@ -3,9 +3,21 @@ import { Route } from 'react-router-dom';
 import { renderWithProviders } from 'test-utils';
 
 import InstructorCard from 'features/Classes/InstructorCard';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
+}));
+
+jest.mock('features/Classes/data/classesApi', () => ({
+  ...jest.requireActual('features/Classes/data/classesApi'),
+  useGetClassesByCourseQuery: jest.fn(),
+}));
+
+jest.mock('features/Instructors/data/instructorsApi', () => ({
+  ...jest.requireActual('features/Instructors/data/instructorsApi'),
+  useGetInstructorsOptionsQuery: jest.fn(),
 }));
 
 const basePath = `/courses/${encodeURIComponent(
@@ -13,6 +25,9 @@ const basePath = `/courses/${encodeURIComponent(
 )}/${encodeURIComponent('ccx-v1')}`;
 
 const stateMock = {
+  main: {
+    selectedInstitution: { id: 1 },
+  },
   instructors: {
     selectOptions: {
       data: [
@@ -41,16 +56,31 @@ const stateMock = {
 };
 
 describe('InstructorCard', () => {
-  const renderComponent = (customState = stateMock) => renderWithProviders(
-    <Route
-      path="/courses/:courseId/:classId"
-      element={<InstructorCard isOpen onClose={() => {}} />}
-    />,
-    {
-      preloadedState: customState,
-      initialEntries: [basePath],
-    },
-  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = (customState = stateMock) => {
+    useGetClassesByCourseQuery.mockReturnValue({
+      data: customState.classes?.allClasses?.data ?? [],
+      isFetching: false,
+    });
+    useGetInstructorsOptionsQuery.mockReturnValue({
+      data: customState.instructors?.selectOptions?.data ?? [],
+      isFetching: false,
+    });
+
+    return renderWithProviders(
+      <Route
+        path="/courses/:courseId/:classId"
+        element={<InstructorCard isOpen onClose={() => {}} />}
+      />,
+      {
+        preloadedState: customState,
+        initialEntries: [basePath],
+      },
+    );
+  };
 
   test('Should render with correct elements', () => {
     const { getByText } = renderComponent();

--- a/src/features/Classes/InstructorCard/index.jsx
+++ b/src/features/Classes/InstructorCard/index.jsx
@@ -1,15 +1,14 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner } from '@openedx/paragon';
 import { Button } from 'react-paragon-topaz';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import { formatDateRange } from 'helpers';
 import { useInstitutionIdQueryParam } from 'hooks';
-import { initialPage, RequestStatus } from 'features/constants';
-import { resetInstructorOptions } from 'features/Instructors/data/slice';
-import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 import InstructorAvatar from 'features/Classes/InstructorAvatar';
 
@@ -18,12 +17,9 @@ import 'features/Classes/InstructorCard/index.scss';
 const INSTRUCTORS_NUMBER = 3;
 
 const InstructorCard = ({ previousPage, children }) => {
-  const dispatch = useDispatch();
   const { classId, courseId } = useParams();
   const navigate = useNavigate();
   const institution = useSelector((state) => state.main.selectedInstitution);
-  const instructors = useSelector((state) => state.instructors.selectOptions.data);
-  const classes = useSelector((state) => state.classes.allClasses);
   const classIdDecoded = decodeURIComponent(classId);
 
   const addQueryParam = useInstitutionIdQueryParam();
@@ -32,9 +28,17 @@ const InstructorCard = ({ previousPage, children }) => {
     navigate(addQueryParam(`/manage-instructors/${courseId}/${classId}?previous=${previousPage}`));
   };
 
-  const isLoadingClasses = classes.status === RequestStatus.LOADING;
+  const { data: classesData = [], isFetching: isLoadingClasses } = useGetClassesByCourseQuery(
+    { institutionId: institution.id, courseId: decodeURIComponent(courseId) },
+    { skip: !institution.id },
+  );
 
-  const [classInfo] = classes.data.filter(
+  const { data: instructors = [] } = useGetInstructorsOptionsQuery(
+    { institutionId: institution.id, filters: { limit: false, class_id: classIdDecoded } },
+    { skip: !institution.id },
+  );
+
+  const [classInfo] = classesData.filter(
     (classElement) => classElement.classId === classIdDecoded,
   );
 
@@ -58,13 +62,6 @@ const InstructorCard = ({ previousPage, children }) => {
     0,
     (purchasedSeats || 0) - (totalEnrollments || 0) - (totalPendingEnrollments || 0),
   );
-
-  useEffect(() => {
-    if (institution.id) {
-      dispatch(fetchInstructorsOptionsData(institution.id, initialPage, { limit: false, class_id: classIdDecoded }));
-    }
-    return () => dispatch(resetInstructorOptions());
-  }, [institution.id, classIdDecoded, dispatch]);
 
   return (
     <article className="instructor-wrapper mb-4">

--- a/src/features/Classes/data/_test_/redux.test.js
+++ b/src/features/Classes/data/_test_/redux.test.js
@@ -2,7 +2,12 @@ import MockAdapter from 'axios-mock-adapter';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { fetchClassesData, fetchAllClassesData } from 'features/Classes/data/thunks';
-import { updateCurrentPage } from 'features/Classes/data/slice';
+import {
+  updateCurrentPage,
+  updateFilters,
+  updateFiltersForm,
+  resetClassesFilters,
+} from 'features/Classes/data/slice';
 import { executeThunk } from 'test-utils';
 import { initializeStore } from 'store';
 
@@ -89,6 +94,18 @@ describe('Classes redux tests', () => {
 
     store.dispatch(updateCurrentPage(newPage));
     expect(store.getState().classes.table).toEqual(expectState);
+  });
+
+  test('reset classes filters clears filters, filters form and current page', () => {
+    store.dispatch(updateFilters({ class_name: 'Demo Class' }));
+    store.dispatch(updateFiltersForm({ classFilter: 'Demo Class' }));
+    store.dispatch(updateCurrentPage(3));
+
+    store.dispatch(resetClassesFilters());
+
+    expect(store.getState().classes.filters).toEqual({});
+    expect(store.getState().classes.filtersForm).toEqual({});
+    expect(store.getState().classes.table.currentPage).toEqual(1);
   });
 
   test('successful fetch all classes data', async () => {

--- a/src/features/Classes/data/classesApi.js
+++ b/src/features/Classes/data/classesApi.js
@@ -1,0 +1,72 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { sortAlphabetically } from 'react-paragon-topaz';
+
+import { getClassesByInstitution } from 'features/Common/data/api';
+import { initialPage } from 'features/constants';
+
+export const classesApi = createApi({
+  reducerPath: 'classesApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['Classes'],
+  endpoints: (builder) => ({
+    getClasses: builder.query({
+      async queryFn({
+        institutionId,
+        page = initialPage,
+        filters = {},
+        limit = true,
+      }) {
+        try {
+          const { courseId = '', ...params } = filters;
+          const response = camelCaseObject(
+            await getClassesByInstitution(institutionId, courseId, limit, page, params),
+          );
+
+          return {
+            data: {
+              results: sortAlphabetically(response.data.results, 'className'),
+              count: response.data.count,
+              numPages: response.data.numPages,
+            },
+          };
+        } catch (error) {
+          return {
+            error: {
+              status: error?.response?.status,
+              message: error?.message,
+            },
+          };
+        }
+      },
+      providesTags: ['Classes'],
+    }),
+    /**
+     * Fetches every class of a given course (no pagination limit).
+     */
+    getClassesByCourse: builder.query({
+      async queryFn({ institutionId, courseId = '' }) {
+        try {
+          const response = camelCaseObject(
+            await getClassesByInstitution(institutionId, courseId, false),
+          );
+
+          return { data: sortAlphabetically(response.data, 'className') };
+        } catch (error) {
+          return {
+            error: {
+              status: error?.response?.status,
+              message: error?.message,
+            },
+          };
+        }
+      },
+      providesTags: ['Classes'],
+    }),
+  }),
+});
+
+export const {
+  useGetClassesQuery,
+  useGetClassesByCourseQuery,
+} = classesApi;

--- a/src/features/Classes/data/slice.js
+++ b/src/features/Classes/data/slice.js
@@ -12,6 +12,7 @@ const initialState = {
     count: 0,
   },
   filters: {},
+  filtersForm: {},
   selectOptions: [],
   allClasses: {
     data: [],
@@ -51,6 +52,17 @@ export const classesSlice = createSlice({
     },
     updateFilters: (state, { payload }) => {
       state.filters = payload;
+    },
+    updateFiltersForm: (state, { payload }) => {
+      state.filtersForm = payload;
+    },
+    resetFiltersForm: (state) => {
+      state.filtersForm = initialState.filtersForm;
+    },
+    resetClassesFilters: (state) => {
+      state.filters = initialState.filters;
+      state.filtersForm = initialState.filtersForm;
+      state.table.currentPage = initialState.table.currentPage;
     },
     updateClassesOptions: (state, { payload }) => {
       state.selectOptions = payload;
@@ -101,6 +113,9 @@ export const {
   fetchClassesDataSuccess,
   fetchClassesDataFailed,
   updateFilters,
+  updateFiltersForm,
+  resetFiltersForm,
+  resetClassesFilters,
   updateClassesOptions,
   fillClassesTable,
   fetchAllClassesDataRequest,

--- a/src/features/Classes/hooks.js
+++ b/src/features/Classes/hooks.js
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { matchPath, useLocation } from 'react-router-dom';
+
+import { resetClassesFilters } from 'features/Classes/data/slice';
+
+/**
+ * Routes that make up the "Classes" experience: the classes list and every
+ * page reached while acting on a specific class. The persisted search context
+ * is preserved while the user navigates between these routes.
+ */
+const CLASSES_CONTEXT_ROUTES = [
+  '/classes',
+  '/courses/:courseId/:classId',
+  '/manage-instructors/:courseId/:classId',
+];
+
+const isClassesContextPath = (pathname) => CLASSES_CONTEXT_ROUTES.some(
+  (route) => matchPath(route, pathname),
+);
+
+/**
+ * Clears the persisted Classes filters when the user leaves the Classes
+ * experience for a different section, keeping them intact while acting on a
+ * class (e.g. assigning an instructor or enrolling a student).
+ */
+export const useResetClassesFiltersOnLeave = () => {
+  const dispatch = useDispatch();
+  const { pathname } = useLocation();
+  const wasInClassesContext = useRef(false);
+
+  useEffect(() => {
+    const inClassesContext = isClassesContextPath(pathname);
+
+    if (wasInClassesContext.current && !inClassesContext) {
+      dispatch(resetClassesFilters());
+    }
+
+    wasInClassesContext.current = inClassesContext;
+  }, [pathname, dispatch]);
+};
+
+export default useResetClassesFiltersOnLeave;

--- a/src/features/Courses/data/coursesApi.js
+++ b/src/features/Courses/data/coursesApi.js
@@ -1,0 +1,40 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { sortAlphabetically } from 'react-paragon-topaz';
+
+import { getCoursesByInstitution } from 'features/Common/data/api';
+import { initialPage } from 'features/constants';
+
+export const coursesApi = createApi({
+  reducerPath: 'coursesApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['CoursesOptions'],
+  endpoints: (builder) => ({
+    getCoursesOptions: builder.query({
+      async queryFn({
+        institutionId,
+        limit = false,
+        page = initialPage,
+        params = {},
+      }) {
+        try {
+          const response = camelCaseObject(
+            await getCoursesByInstitution(institutionId, limit, page, params),
+          );
+
+          return { data: sortAlphabetically(response.data) };
+        } catch (error) {
+          return {
+            error: {
+              status: error?.response?.status,
+              message: error?.message,
+            },
+          };
+        }
+      },
+      providesTags: ['CoursesOptions'],
+    }),
+  }),
+});
+
+export const { useGetCoursesOptionsQuery } = coursesApi;

--- a/src/features/Instructors/ManageInstructors/ListInstructors.jsx
+++ b/src/features/Instructors/ManageInstructors/ListInstructors.jsx
@@ -11,13 +11,12 @@ import { Button } from 'react-paragon-topaz';
 
 import DeleteModal from 'features/Common/DeleteModal';
 
-import { assignInstructors, fetchInstructorsOptionsData } from 'features/Instructors/data';
-import { RequestStatus, initialPage } from 'features/constants';
+import { assignInstructors } from 'features/Instructors/data';
+import { RequestStatus } from 'features/constants';
 
 const ListInstructors = ({ instructors, isLoadingInstructors }) => {
   const dispatch = useDispatch();
 
-  const institution = useSelector((state) => state.main.selectedInstitution);
   const statusAssignRequest = useSelector((state) => state.instructors.assignInstructors.status);
 
   const { classId } = useParams();
@@ -47,7 +46,6 @@ const ListInstructors = ({ instructors, isLoadingInstructors }) => {
       };
 
       await dispatch(assignInstructors(instructorData));
-      dispatch(fetchInstructorsOptionsData(institution.id, initialPage, { limit: false, class_id: classIdDecoded }));
     } catch (error) {
       logError(error);
       setShowToast(true);

--- a/src/features/Instructors/ManageInstructors/_test_/index.test.jsx
+++ b/src/features/Instructors/ManageInstructors/_test_/index.test.jsx
@@ -5,9 +5,21 @@ import { renderWithProviders } from 'test-utils';
 import { RequestStatus } from 'features/constants';
 
 import ManageInstructors from 'features/Instructors/ManageInstructors';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
+}));
+
+jest.mock('features/Classes/data/classesApi', () => ({
+  ...jest.requireActual('features/Classes/data/classesApi'),
+  useGetClassesByCourseQuery: jest.fn(),
+}));
+
+jest.mock('features/Instructors/data/instructorsApi', () => ({
+  ...jest.requireActual('features/Instructors/data/instructorsApi'),
+  useGetInstructorsOptionsQuery: jest.fn(),
 }));
 
 const mockStore = {
@@ -66,6 +78,18 @@ const courseId = encodeURIComponent('course-v1:XXX+YYY+2023');
 const classId = encodeURIComponent('ccx-v1:XXX+YYY+2023+ccx@111');
 
 describe('Manage instructors page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useGetClassesByCourseQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+    });
+    useGetInstructorsOptionsQuery.mockReturnValue({
+      data: mockStore.instructors.selectOptions.data,
+      isFetching: false,
+    });
+  });
+
   test('render page', async () => {
     const { getByText, getAllByRole, getByTestId } = renderWithProviders(
       <Route

--- a/src/features/Instructors/ManageInstructors/index.jsx
+++ b/src/features/Instructors/ManageInstructors/index.jsx
@@ -13,12 +13,11 @@ import { Button } from 'react-paragon-topaz';
 import ListInstructors from 'features/Instructors/ManageInstructors/ListInstructors';
 import AssignSection from 'features/Instructors/ManageInstructors/AssignSection';
 
-import { RequestStatus, initialPage } from 'features/constants';
-import { resetClassesTable, resetClasses } from 'features/Classes/data/slice';
-import { fetchAllClassesData } from 'features/Classes/data/thunks';
 import { updateFilters, resetRowSelect } from 'features/Instructors/data/slice';
-import { assignInstructors, fetchInstructorsOptionsData } from 'features/Instructors/data';
+import { assignInstructors } from 'features/Instructors/data';
 import { updateActiveTab } from 'features/Main/data/slice';
+import { useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
 import 'features/Instructors/ManageInstructors/index.scss';
 
@@ -32,12 +31,10 @@ const ManageInstructors = () => {
   const [toastMessage, setToastMessage] = useState('');
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
   const rowsSelected = useSelector((state) => state.instructors.rowsSelected);
-  const instructorsByClass = useSelector((state) => state.instructors.selectOptions);
 
   const { courseId, classId } = useParams();
   const queryParams = new URLSearchParams(location.search);
   const previousPage = queryParams.get('previous') || 'courses';
-  const isLoadingInstructors = instructorsByClass?.status === RequestStatus.LOADING;
   const isButtonDisabled = rowsSelected.length === 0;
   const classIdDecoded = decodeURIComponent(classId);
   const courseIdDecoded = decodeURIComponent(courseId);
@@ -47,7 +44,20 @@ const ManageInstructors = () => {
     masterCourseName: '',
   }), []);
 
-  const classInfo = useSelector((state) => state.classes.allClasses.data)
+  const { data: classesByCourse = [] } = useGetClassesByCourseQuery(
+    { institutionId: selectedInstitution.id, courseId: courseIdDecoded },
+    { skip: !selectedInstitution.id },
+  );
+
+  const {
+    data: instructorsByClass = [],
+    isFetching: isLoadingInstructors,
+  } = useGetInstructorsOptionsQuery(
+    { institutionId: selectedInstitution.id, filters: { limit: false, class_id: classIdDecoded } },
+    { skip: !selectedInstitution.id },
+  );
+
+  const classInfo = classesByCourse
     .find((classElement) => classElement?.classId === classIdDecoded) || defaultClassInfo;
 
   const resetValues = () => {
@@ -72,11 +82,6 @@ const ManageInstructors = () => {
       };
 
       await dispatch(assignInstructors(enrollmentData));
-      dispatch(fetchInstructorsOptionsData(
-        selectedInstitution.id,
-        initialPage,
-        { limit: false, class_id: classIdDecoded },
-      ));
       if (rowsSelected.length === 1) {
         setToastMessage(`${rowsSelected[0]} has been successfully assigned to Class ${classInfo.className}`);
       } else if (rowsSelected.length > 1) {
@@ -94,19 +99,8 @@ const ManageInstructors = () => {
     if (selectedInstitution.id) {
       // Leaves a gap time space to prevent being override by ActiveTabUpdater component
       setTimeout(() => dispatch(updateActiveTab(previousPage)), 100);
-      dispatch(fetchInstructorsOptionsData(
-        selectedInstitution.id,
-        initialPage,
-        { limit: false, class_id: classIdDecoded },
-      ));
-      dispatch(fetchAllClassesData(selectedInstitution.id, courseIdDecoded));
     }
-
-    return () => {
-      dispatch(resetClassesTable());
-      dispatch(resetClasses());
-    };
-  }, [dispatch, selectedInstitution.id, previousPage, classIdDecoded, courseIdDecoded]);
+  }, [dispatch, selectedInstitution.id, previousPage]);
 
   return (
     <>
@@ -129,7 +123,7 @@ const ManageInstructors = () => {
           <h4 className="class-name">{classInfo.className}</h4>
           <p className="course-name">{classInfo.masterCourseName}</p>
         </div>
-        <ListInstructors instructors={instructorsByClass?.data} isLoadingInstructors={isLoadingInstructors} />
+        <ListInstructors instructors={instructorsByClass} isLoadingInstructors={isLoadingInstructors} />
         <AssignSection ref={cancelButtonRef} />
         <div className="d-flex col-12 justify-content-end align-items-start p-0 mt-4">
           <Button

--- a/src/features/Instructors/data/instructorsApi.js
+++ b/src/features/Instructors/data/instructorsApi.js
@@ -1,0 +1,34 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { camelCaseObject } from '@edx/frontend-platform';
+
+import { getInstructorByInstitution } from 'features/Common/data/api';
+import { initialPage } from 'features/constants';
+
+export const instructorsApi = createApi({
+  reducerPath: 'instructorsApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['InstructorsOptions'],
+  endpoints: (builder) => ({
+    getInstructorsOptions: builder.query({
+      async queryFn({ institutionId, page = initialPage, filters = {} }) {
+        try {
+          const response = camelCaseObject(
+            await getInstructorByInstitution(institutionId, page, filters),
+          );
+
+          return { data: response.data };
+        } catch (error) {
+          return {
+            error: {
+              status: error?.response?.status,
+              message: error?.message,
+            },
+          };
+        }
+      },
+      providesTags: ['InstructorsOptions'],
+    }),
+  }),
+});
+
+export const { useGetInstructorsOptionsQuery } = instructorsApi;

--- a/src/features/Instructors/data/thunks.js
+++ b/src/features/Instructors/data/thunks.js
@@ -1,6 +1,8 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { getInstructorByInstitution } from 'features/Common/data/api';
+import { classesApi } from 'features/Classes/data/classesApi';
+import { instructorsApi } from 'features/Instructors/data/instructorsApi';
 import {
   handleInstructorsEnrollment,
   handleNewInstructor,
@@ -63,6 +65,8 @@ function assignInstructors(data) {
     try {
       const response = await handleInstructorsEnrollment(data);
       dispatch(assignInstructorsSuccess(response.data));
+      dispatch(classesApi.util.invalidateTags(['Classes']));
+      dispatch(instructorsApi.util.invalidateTags(['InstructorsOptions']));
     } catch (error) {
       dispatch(assignInstructorsFailed());
       logError(error);

--- a/src/features/Main/DeleteEnrollment/index.jsx
+++ b/src/features/Main/DeleteEnrollment/index.jsx
@@ -16,6 +16,7 @@ import {
 import {
   fetchStudentsDataSuccess,
 } from 'features/Students/data/slice';
+import { studentsApi } from 'features/Students/data/studentsApi';
 import { deleteEnrollment } from 'features/Main/data/api';
 
 /**
@@ -62,6 +63,8 @@ const DeleteEnrollment = ({ studentEmail, classId }) => {
           results: updatedStudents,
           count: updatedStudents.length,
         }));
+
+        dispatch(studentsApi.util.invalidateTags(['StudentsClass']));
 
         setMessage('Enrollment deleted successfully.');
         closeConfirmation();

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -38,6 +38,7 @@ import { fetchInstitutionData } from 'features/Main/data/thunks';
 import { updateSelectedInstitution } from 'features/Main/data/slice';
 
 import { useInstitutionIdQueryParam } from 'hooks';
+import { useResetClassesFiltersOnLeave } from 'features/Classes/hooks';
 
 import { cookieText, INSTITUTION_QUERY_ID, RequestStatus } from 'features/constants';
 
@@ -60,6 +61,8 @@ const Main = () => {
 
   const requiredRoles = [USER_ROLES.GLOBAL_STAFF, USER_ROLES.INSTITUTION_ADMIN];
   const isAuthorizedUser = requiredRoles.some(role => roles.includes(role));
+
+  useResetClassesFiltersOnLeave();
 
   useEffect(() => {
     dispatch(fetchInstitutionData());

--- a/src/features/Students/data/__test__/api.test.js
+++ b/src/features/Students/data/__test__/api.test.js
@@ -1,5 +1,5 @@
 import {
-  getStudentbyInstitutionAdmin, handleEnrollments,
+  getStudentsByInstitutionId, handleEnrollments,
 } from 'features/Students/data/api';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { MAX_TABLE_RECORDS } from 'features/constants';
@@ -15,7 +15,7 @@ jest.mock('@edx/frontend-platform', () => ({
   })),
 }));
 
-describe('getStudentbyInstitutionAdmin', () => {
+describe('getStudentsByInstitutionId', () => {
   test('should call getAuthenticatedHttpClient with the correct parameters', () => {
     const httpClientMock = {
       get: jest.fn(),
@@ -26,7 +26,7 @@ describe('getStudentbyInstitutionAdmin', () => {
 
     getAuthenticatedHttpClient.mockReturnValue(httpClientMock);
 
-    getStudentbyInstitutionAdmin(institutionId, page);
+    getStudentsByInstitutionId(institutionId, page);
 
     expect(getAuthenticatedHttpClient).toHaveBeenCalledTimes(1);
     expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();

--- a/src/features/Students/data/api.js
+++ b/src/features/Students/data/api.js
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 import { MAX_TABLE_RECORDS } from 'features/constants';
 
-function getStudentbyInstitutionAdmin(institutionId, page, filters) {
+function getStudentsByInstitutionId(institutionId, page, filters) {
   const params = {
     page,
     page_size: MAX_TABLE_RECORDS,
@@ -97,7 +97,7 @@ function getInstitutionVouchersByExamSeriesCode(examSeriesCode) {
 }
 
 export {
-  getStudentbyInstitutionAdmin,
+  getStudentsByInstitutionId,
   handleEnrollments,
   getStudentsMetrics,
   getClassesMetrics,

--- a/src/features/Students/data/studentsApi.js
+++ b/src/features/Students/data/studentsApi.js
@@ -1,0 +1,47 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { camelCaseObject } from '@edx/frontend-platform';
+
+import { getStudentsByInstitutionId } from 'features/Students/data/api';
+import { initialPage } from 'features/constants';
+
+export const studentsApi = createApi({
+  reducerPath: 'studentsApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['StudentsClass'],
+  endpoints: (builder) => ({
+    getStudentsByClass: builder.query({
+      async queryFn({
+        institutionId,
+        page = initialPage,
+        courseId,
+        classId,
+      }) {
+        try {
+          const response = camelCaseObject(await getStudentsByInstitutionId(institutionId, page, {
+            course_id: courseId,
+            class_id: classId,
+            limit: true,
+          }));
+
+          return {
+            data: {
+              results: response.data.results,
+              count: response.data.count,
+              numPages: response.data.numPages,
+            },
+          };
+        } catch (error) {
+          return {
+            error: {
+              status: error?.response?.status,
+              message: error?.message,
+            },
+          };
+        }
+      },
+      providesTags: ['StudentsClass'],
+    }),
+  }),
+});
+
+export const { useGetStudentsByClassQuery } = studentsApi;

--- a/src/features/Students/data/thunks.js
+++ b/src/features/Students/data/thunks.js
@@ -20,7 +20,7 @@ import {
   getClassesMetrics,
   getStudentsMetrics,
   getStudentsByEmail,
-  getStudentbyInstitutionAdmin,
+  getStudentsByInstitutionId,
   getInstitutionVouchersByExamSeriesCode,
 } from 'features/Students/data/api';
 import { RequestStatus } from 'features/constants';
@@ -30,7 +30,7 @@ function fetchStudentsData(id, currentPage, filtersData) {
     dispatch(fetchStudentsDataRequest());
 
     try {
-      const response = camelCaseObject(await getStudentbyInstitutionAdmin(id, currentPage, filtersData));
+      const response = camelCaseObject(await getStudentsByInstitutionId(id, currentPage, filtersData));
       dispatch(fetchStudentsDataSuccess(response.data));
     } catch (error) {
       dispatch(fetchStudentsDataFailed());

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { setupListeners } from '@reduxjs/toolkit/query';
 import { reducer as instructorsReducer } from 'features/Instructors/data';
 import { reducer as mainReducer } from 'features/Main/data';
 import { reducer as coursesReducer } from 'features/Courses/data';
@@ -6,6 +7,10 @@ import { reducer as studentsReducer } from 'features/Students/data';
 import { reducer as dashboardReducer } from 'features/Dashboard/data';
 import { reducer as licensesReducer } from 'features/Licenses/data';
 import { reducer as classesReducer } from 'features/Classes/data';
+import { classesApi } from 'features/Classes/data/classesApi';
+import { coursesApi } from 'features/Courses/data/coursesApi';
+import { instructorsApi } from 'features/Instructors/data/instructorsApi';
+import { studentsApi } from 'features/Students/data/studentsApi';
 
 export function initializeStore(preloadedState = undefined) {
   return configureStore({
@@ -17,9 +22,21 @@ export function initializeStore(preloadedState = undefined) {
       dashboard: dashboardReducer,
       licenses: licensesReducer,
       classes: classesReducer,
+      [classesApi.reducerPath]: classesApi.reducer,
+      [coursesApi.reducerPath]: coursesApi.reducer,
+      [instructorsApi.reducerPath]: instructorsApi.reducer,
+      [studentsApi.reducerPath]: studentsApi.reducer,
     },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(
+      classesApi.middleware,
+      coursesApi.middleware,
+      instructorsApi.middleware,
+      studentsApi.middleware,
+    ),
     preloadedState,
   });
 }
 
 export const store = initializeStore();
+
+setupListeners(store.dispatch);


### PR DESCRIPTION
# Description

This PR migrates the Classes feature and its related data fetching (Courses, Instructors, and Students) from thunk-based requests to RTK Query. The migration reduces boilerplate, leverages RTK Query caching and tag invalidation, and preserves the user's search state when navigating away from and back to the Classes page.

# Ticket
https://pearson.atlassian.net/browse/PADV-3481

# Changes
- Migrated Classes data fetching to RTK Query.
- Added `classesApi` with:
  - `getClasses`
  - `getClassesByCourse`
- Added `coursesApi` with `getCoursesOptions`.
- Added `instructorsApi` with `getInstructorsOptions`.
- Added `studentsApi` with `getStudentsByClass`.
- Registered all RTK Query API slices in the Redux store, including middleware and `setupListeners`.
- Replaced thunk-based fetching with RTK Query hooks across the Classes feature.
- Added persisted `filtersForm` state to the Classes slice.
- Added reducers to update and reset persisted filter values.
- Updated the Classes page to use cached query results instead of manual fetch/reset lifecycle logic.
- Updated the Classes filters component to restore previously applied filter values from Redux.
- Replaced manual refetch logic with RTK Query tag invalidation after mutations.
- Migrated Class detail components to use RTK Query hooks.
- Renamed `getStudentbyInstitutionAdmin` to `getStudentsByInstitutionId` for consistency.
- Updated unit tests to mock the new RTK Query hooks and APIs.

# How to test
- Open the **Classes** page.
- Perform searches using different combinations of filters.
- Verify the filtered results are displayed correctly.
- Open a class from the filtered results.
- Perform each supported action, including:
  - Assign an instructor.
  - Remove an instructor.
  - Enroll a student.
  - Remove a student enrollment.
  - Delete a class (if applicable).
- Return to the Classes page using the back navigation.
- Verify:
  - The previously applied filters are still populated.
  - The filtered results are preserved.
  - The current pagination is maintained.
  - The page does not reset to the full Classes list.
- Verify Courses, Instructors, and Students selectors continue loading their options correctly.
- Confirm data updates correctly after mutations without requiring a manual page refresh.
- Run the updated unit test suite and verify all affected tests pass.