### PR TITLE
fix: last access date for pending enrollments

### DIFF
--- a/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
@@ -130,6 +130,42 @@ describe('getColumns', () => {
     expect(getByText('Active')).toBeInTheDocument();
   });
 
+  test('renders Last access date formatted', () => {
+    const cols = getColumns();
+
+    const LastAccessCell = () => cols[3].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('03/15/24')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when enrollment is pending', () => {
+    const cols = getColumns();
+
+    const LastAccessCell = () => cols[3].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'pending' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when null', () => {
+    const cols = getColumns();
+
+    const LastAccessCell = () => cols[3].Cell({
+      row: { original: { lastAccess: null, status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
   test('renders Current Grade with safe value', () => {
     const columns = getColumns();
 

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -57,7 +57,8 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
     Header: 'Last access date',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
-      const lastAccess = row.original.lastAccess
+      const isPending = row.original.status?.toLowerCase() === 'pending';
+      const lastAccess = !isPending && row.original.lastAccess
         ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
         : '--';
       return <span>{lastAccess}</span>;

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -94,6 +94,36 @@ describe('StudentsTable Columns', () => {
     expect(actionCol).toHaveProperty('accessor', 'classId');
   });
 
+  test('renders Last access date formatted', () => {
+    const LastAccessCell = () => columns[2].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('03/15/24')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when enrollment is pending', () => {
+    const LastAccessCell = () => columns[2].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'pending' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when null', () => {
+    const LastAccessCell = () => columns[2].Cell({
+      row: { original: { lastAccess: null, status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
   test('renders dropdown menu correctly', async () => {
     const ActionColumn = () => columns[10].Cell({
       row: {

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -51,7 +51,8 @@ const columns = [
     Header: 'Last access date',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
-      const lastAccess = row.original.lastAccess
+      const isPending = row.original.status?.toLowerCase() === 'pending';
+      const lastAccess = !isPending && row.original.lastAccess
         ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
         : '--';
       return <span>{lastAccess}</span>;


### PR DESCRIPTION
# Description
When a student's enrollment status is pending, the Last access date column was displaying a date that does not correspond to an actual course access. This fix ensures the column renders -- instead of a date for pending enrollments.

Changes
- Added a pending status check in the Last access date Cell renderer for the Students and Classes tables.
- The column now renders -- when row.original.status is 'pending', regardless of the lastAccess value.

Files changed
- src/features/Students/StudentsTable/columns.jsx
- src/features/Classes/ClassDetailPage/columns.jsx 

## Before
<img width="1372" height="175" alt="Screenshot 2026-07-08 at 3 09 42 PM" src="https://github.com/user-attachments/assets/1f8f56d4-a112-482b-a5e5-858814bf4cc0" />

## After
<img width="1412" height="565" alt="Screenshot 2026-07-08 at 3 06 04 PM" src="https://github.com/user-attachments/assets/007f0844-d5f3-4ad7-99ae-92b20663986e" />