### PR TITLE
PADV-3503: Inactive instructors should not be visible in Instructor dropdown menu when creating a new class

### DIFF
--- a/src/features/Courses/AddClass/_test_/index.test.jsx
+++ b/src/features/Courses/AddClass/_test_/index.test.jsx
@@ -1,26 +1,26 @@
 import { waitFor, fireEvent } from '@testing-library/react';
 import { Route } from 'react-router-dom';
 import AddClass from 'features/Courses/AddClass';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 import { renderWithProviders } from 'test-utils';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 
-const mockStore = {
-  instructors: {
-    selectOptions: {
-      data: [
-        {
-          masterCourseName: 'Demo Course 1',
-          numberOfClasses: 1,
-          missingClassesForInstructor: null,
-          numberOfStudents: 1,
-          numberOfPendingStudents: 11,
-        },
-      ],
-    },
-  },
+jest.mock('features/Instructors/data/instructorsApi', () => ({
+  ...jest.requireActual('features/Instructors/data/instructorsApi'),
+  useGetInstructorsOptionsQuery: jest.fn(),
+}));
+
+const instructorOption = {
+  masterCourseName: 'Demo Course 1',
+  numberOfClasses: 1,
+  missingClassesForInstructor: null,
+  numberOfStudents: 1,
+  numberOfPendingStudents: 11,
+  instructorName: 'Sam Sepiol',
+  instructorUsername: 's4mS3pi0l',
 };
 
 const courseInfoMocked = {
@@ -33,6 +33,13 @@ const basePath = `/courses/${encodeURIComponent(
 )}`;
 
 describe('Add class modal', () => {
+  beforeEach(() => {
+    useGetInstructorsOptionsQuery.mockReturnValue({
+      data: [instructorOption],
+      isLoading: false,
+    });
+  });
+
   const renderComponent = () => renderWithProviders(
     <Route
       path="/courses/:courseId"
@@ -45,7 +52,6 @@ describe('Add class modal', () => {
         )}
     />,
     {
-      preloadedState: mockStore,
       initialEntries: [basePath],
     },
   );

--- a/src/features/Courses/AddClass/index.jsx
+++ b/src/features/Courses/AddClass/index.jsx
@@ -17,12 +17,15 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { addClass, editClass } from 'features/Courses/data';
-import { fetchInstructorsOptionsData } from 'features/Instructors/data/thunks';
+import { useGetInstructorsOptionsQuery } from 'features/Instructors/data/instructorsApi';
 
-import { initialPage } from 'features/constants';
 import { formatUTCDate } from 'helpers';
 
 import 'features/Courses/AddClass/index.scss';
+
+// Stable empty array reference to avoid re-triggering the mapping effect while
+// the cached query is loading (a new [] on every render would cause a loop).
+const EMPTY_OPTIONS = [];
 
 const AddClass = ({
   isOpen, onClose, courseInfo, isEditing, finalCall,
@@ -30,7 +33,10 @@ const AddClass = ({
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const selectedInstitution = useSelector((state) => state.main.selectedInstitution);
-  const instructorsList = useSelector((state) => state.instructors.selectOptions.data);
+  const { data: instructorsList = EMPTY_OPTIONS, isLoading: isLoadingInstructors } = useGetInstructorsOptionsQuery(
+    { institutionId: selectedInstitution?.id, filters: { limit: false, active: true } },
+    { skip: !selectedInstitution?.id || isEditing || !isOpen },
+  );
   const notificationMsg = useSelector((state) => state.courses.notificationMessage);
   const [showToast, setShowToast] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -123,12 +129,6 @@ const AddClass = ({
   };
 
   useEffect(() => {
-    if (Object.keys(selectedInstitution).length > 0 && isOpen && !isEditing) {
-      dispatch(fetchInstructorsOptionsData(selectedInstitution.id, initialPage, { limit: false }));
-    }
-  }, [selectedInstitution, isOpen, dispatch, isEditing]);
-
-  useEffect(() => {
     if (instructorsList.length > 0) {
       const options = instructorsList.map(instructor => ({
         ...instructor,
@@ -202,6 +202,8 @@ const AddClass = ({
                   options={instructorsOptions}
                   onChange={option => setInstructorSelected(option)}
                   value={instructorSelected}
+                  isLoading={isLoadingInstructors}
+                  isDisabled={isLoadingInstructors}
                 />
               </Form.Group>
             )}


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-3503

# Description

When creating a new class, staff/admins can currently select inactive instructors because the instructor dropdown lists every instructor returned by the backend regardless of status. Assigning a class to an inactive instructor is invalid and can lead to classes with an instructor who can no longer teach, causing data-integrity and operational issues. Limiting the dropdown to active instructors prevents invalid assignments at the source and makes Add Class consistent with the rest of the portal, where the assign-instructor flow already filters to active instructors only.


## Change log
- src/features/Courses/AddClass/_test_/index.test.jsx
- src/features/Courses/AddClass/index.jsx
- src/features/Instructors/data/__test__/redux.test.js
- src/features/Instructors/data/slice.js
- src/features/Instructors/data/thunks.js

### How to test
- Log in and navigate to a course's classes and open Add Class.
- In the browser DevTools Network tab, confirm the /instructors/ request URL contains active=true.
- Confirm the dropdown lists only active instructors (cross-check against the Instructors page filtered by Active/Inactive tabs).
- In a data set that has an existing class assigned to an inactive instructor, open Add Class and then look at the class table behind/after — the inactive instructor's name must still render (no regression to raw username).
- Create a class selecting an active instructor and confirm it is created and the instructor is assigned.