### PR TITLE
PADV-3572 - Change "Last Access Date" label in Class Roster to "Last Login".

### DIFF
--- a/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
@@ -79,7 +79,7 @@ describe('getColumns', () => {
     expect(number).toHaveProperty('Header', 'No');
     expect(student).toHaveProperty('Header', 'Student');
     expect(learnerEmail).toHaveProperty('Header', 'Email');
-    expect(lastAccessDate).toHaveProperty('Header', 'Last access date');
+    expect(lastAccessDate).toHaveProperty('Header', 'Last Login');
     expect(status).toHaveProperty('Header', 'Status');
     expect(voucherStatus).toHaveProperty('Header', 'Voucher Status');
     expect(completePercentage).toHaveProperty('Header', 'Current Grade');

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -54,7 +54,7 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
     ),
   },
   {
-    Header: 'Last access date',
+    Header: 'Last Login',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
       const isPending = row.original.status?.toLowerCase() === 'pending';

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -67,7 +67,7 @@ describe('StudentsTable Columns', () => {
     expect(emailCol).toHaveProperty('Header', 'Email');
     expect(emailCol).toHaveProperty('accessor', 'learnerEmail');
 
-    expect(lastAccessDateCol).toHaveProperty('Header', 'Last access date');
+    expect(lastAccessDateCol).toHaveProperty('Header', 'Last Login');
     expect(lastAccessDateCol).toHaveProperty('accessor', 'lastAccess');
 
     expect(statusCol).toHaveProperty('Header', 'Status');

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -48,7 +48,7 @@ const columns = [
     ),
   },
   {
-    Header: 'Last access date',
+    Header: 'Last Login',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
       const isPending = row.original.status?.toLowerCase() === 'pending';


### PR DESCRIPTION
Summary
-------
The column previously labeled "Last access date" displays the user's last login
timestamp, not the last time they accessed class content. To avoid confusion and
accurately represent the data being shown, this PR updates the column header to
"Last Login". This is a UI-only change; the underlying data source, sorting,
filtering, and formatting logic remain untouched.

## Ticket
https://pearson.atlassian.net/browse/PADV-3572

Affected Views
--------------
- /students
- /classes/:classId

Changes
-------
- Updated the column header from "Last access date" to "Last Login" in:
  - src/features/Students/StudentsTable/columns.jsx
  - src/features/Classes/Class/ClassPage/columns.jsx
- Updated the corresponding label assertions in:
  - src/features/Students/StudentsTable/__test__/columns.test.jsx
  - src/features/Classes/Class/ClassPage/__test__/columns.test.jsx

Testing
-------
- All affected unit/component tests pass (26 passed).
- Manually verified the header displays "Last Login" in both /students and
  /classes/:classId, with displayed date values unchanged.

How to Test
-----------
1. Open the /students page and verify the column header displays "Last Login".
2. Open /classes/:classId and verify the same column displays "Last Login".
3. Confirm the displayed dates remain unchanged.
4. Verify that sorting (if available) continues to work correctly.
5. Confirm that no other functionality is affected.

