### PR TITLE
feat: add pass/fail widget in Classes view.

### DIFF
--- a/src/features/Classes/ClassAnalyticsWidgets/__test__/index.test.jsx
+++ b/src/features/Classes/ClassAnalyticsWidgets/__test__/index.test.jsx
@@ -116,6 +116,12 @@ describe('ClassAnalyticsWidgets', () => {
             formatted_trend: '+2%',
             trend_direction: 'up',
           },
+          {
+            key: 'pass_fail_rate',
+            title: 'Pass/Fail Rate',
+            formatted_value: '88%',
+            subtitle: '7 passed, 1 failed',
+          },
         ],
       },
     });
@@ -126,6 +132,9 @@ describe('ClassAnalyticsWidgets', () => {
     expect(getByText('Class Average Score')).toBeInTheDocument();
     expect(getByText('100.0%')).toBeInTheDocument();
     expect(getByText('+2%')).toBeInTheDocument();
+    expect(getByText('Pass/Fail Rate')).toBeInTheDocument();
+    expect(getByText('88%')).toBeInTheDocument();
+    expect(getByText('7 passed, 1 failed')).toBeInTheDocument();
     expect(getClassAnalyticsWidgets).toHaveBeenCalledWith({
       institutionId: 2,
       classId,

--- a/src/features/Classes/ClassAnalyticsWidgets/index.jsx
+++ b/src/features/Classes/ClassAnalyticsWidgets/index.jsx
@@ -83,6 +83,7 @@ const ClassAnalyticsWidgets = ({ classId }) => {
             key={widget.key}
             title={widget.title}
             value={widget.formattedValue || widget.formatted_value}
+            subtitle={widget.subtitle}
             trend={widget.formattedTrend || widget.formatted_trend}
             trendDirection={widget.trendDirection || widget.trend_direction}
             hasError={widget.error}

--- a/src/features/Common/MetricCard/__test__/index.test.jsx
+++ b/src/features/Common/MetricCard/__test__/index.test.jsx
@@ -20,6 +20,28 @@ describe('MetricCard', () => {
     expect(getByText('-')).toBeInTheDocument();
   });
 
+  test('renders an optional subtitle', () => {
+    const { getByText } = render(
+      <MetricCard
+        title="Pass/Fail Rate"
+        value="88%"
+        subtitle="7 passed, 1 failed"
+      />,
+    );
+
+    expect(getByText('Pass/Fail Rate')).toBeInTheDocument();
+    expect(getByText('88%')).toBeInTheDocument();
+    expect(getByText('7 passed, 1 failed')).toBeInTheDocument();
+  });
+
+  test('preserves a numeric zero value', () => {
+    const { getByText } = render(
+      <MetricCard title="Pass/Fail Rate" value={0} />,
+    );
+
+    expect(getByText('0')).toBeInTheDocument();
+  });
+
   test('renders trend and up icon when trend direction is up', () => {
     const { container, getByText } = render(
       <MetricCard

--- a/src/features/Common/MetricCard/index.jsx
+++ b/src/features/Common/MetricCard/index.jsx
@@ -6,6 +6,7 @@ import 'features/Common/MetricCard/index.scss';
 const MetricCard = ({
   title,
   value,
+  subtitle,
   trend,
   trendDirection,
   isLoading,
@@ -28,21 +29,29 @@ const MetricCard = ({
       </h5>
 
       <div className="metric-card__value">
-        {value || '-'}
+        {value ?? '-'}
       </div>
 
       <div className="metric-card__footer">
-        {trend && (
-          <span className={`metric-card__trend metric-card__trend--${trendDirection}`}>
-            {trend}
-            {trendDirection === 'up' && (
-              <i className="fa-solid fa-arrow-trend-up ml-2" aria-hidden="true" />
-            )}
-            {trendDirection === 'down' && (
-              <i className="fa-solid fa-arrow-trend-down ml-2" aria-hidden="true" />
-            )}
-          </span>
-        )}
+        <div className="metric-card__footer-content">
+          {subtitle && (
+            <span className="metric-card__subtitle">
+              {subtitle}
+            </span>
+          )}
+
+          {trend && (
+            <span className={`metric-card__trend metric-card__trend--${trendDirection}`}>
+              {trend}
+              {trendDirection === 'up' && (
+                <i className="fa-solid fa-arrow-trend-up ml-2" aria-hidden="true" />
+              )}
+              {trendDirection === 'down' && (
+                <i className="fa-solid fa-arrow-trend-down ml-2" aria-hidden="true" />
+              )}
+            </span>
+          )}
+        </div>
 
         {showInfoIcon && (
           <i className="fa-regular fa-circle-info metric-card__info-icon" aria-hidden="true" />
@@ -56,16 +65,18 @@ MetricCard.propTypes = {
   hasError: PropTypes.bool,
   isLoading: PropTypes.bool,
   showInfoIcon: PropTypes.bool,
+  subtitle: PropTypes.string,
   title: PropTypes.string.isRequired,
   trend: PropTypes.string,
   trendDirection: PropTypes.oneOf(['up', 'down', 'neutral']),
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 MetricCard.defaultProps = {
   hasError: false,
   isLoading: false,
   showInfoIcon: true,
+  subtitle: null,
   trend: null,
   trendDirection: 'neutral',
   value: '-',

--- a/src/features/Common/MetricCard/index.scss
+++ b/src/features/Common/MetricCard/index.scss
@@ -37,6 +37,21 @@
   min-height: 1.25rem;
 }
 
+.metric-card__footer-content {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.metric-card__subtitle {
+  color: #5f6368;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
 .metric-card__trend {
   align-items: center;
   display: inline-flex;

--- a/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
+++ b/src/features/Courses/CoursesDetailPage/__test__/index.test.jsx
@@ -1,4 +1,4 @@
-import { waitFor, fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { Route } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
@@ -15,6 +15,9 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 jest.mock('features/Classes/data/thunks', () => ({
   fetchClassesData: jest.fn(() => () => Promise.resolve()),
 }));
+
+const courseId = 'course-v1:XXX+YYY+2023';
+const secondCourseId = 'course-v1:XXX+ZZZ+2023';
 
 const mockStore = {
   main: {
@@ -44,6 +47,7 @@ const mockStore = {
     table: {
       data: [
         {
+          masterCourseId: courseId,
           masterCourseName: 'Demo Course 1',
           numberOfClasses: 3,
           missingClassesForInstructor: 0,
@@ -51,6 +55,7 @@ const mockStore = {
           numberOfPendingStudents: 0,
         },
         {
+          masterCourseId: secondCourseId,
           masterCourseName: 'Demo Course 2',
           numberOfClasses: 3,
           missingClassesForInstructor: 0,
@@ -64,6 +69,7 @@ const mockStore = {
     },
     selectOptions: [
       {
+        masterCourseId: courseId,
         masterCourseName: 'Demo Course 1',
         numberOfClasses: 3,
         missingClassesForInstructor: 0,
@@ -71,6 +77,7 @@ const mockStore = {
         numberOfPendingStudents: 0,
       },
       {
+        masterCourseId: secondCourseId,
         masterCourseName: 'Demo Course 2',
         numberOfClasses: 3,
         missingClassesForInstructor: 0,
@@ -130,7 +137,7 @@ const mockStore = {
   },
 };
 
-const route = '/courses/course-v1:XXX+YYY+2023';
+const route = `/courses/${courseId}`;
 
 const renderComponent = (store = mockStore) => renderWithProviders(
   <Route path="/courses/:courseId" element={<CoursesDetailPage />} />,
@@ -148,16 +155,15 @@ describe('CoursesDetailPage', () => {
   test('Should render the table and the course info', async () => {
     const { container } = renderComponent();
 
-    waitFor(() => {
-      expect(container).toHaveTextContent('Demo Course 1 1');
+    await waitFor(() => {
+      expect(container).toHaveTextContent('Demo Course 1');
+      expect(container).toHaveTextContent('3 / 3');
       expect(container).toHaveTextContent('Demo MasterCourse 1');
       expect(container).toHaveTextContent('Demo MasterCourse 2');
       expect(container).toHaveTextContent('Demo Class 1');
       expect(container).toHaveTextContent('Demo Class 2');
       expect(container).toHaveTextContent('09/21/24');
       expect(container).toHaveTextContent('09/21/25');
-      expect(container).toHaveTextContent('1');
-      expect(container).toHaveTextContent('2');
       expect(container).toHaveTextContent('100');
       expect(container).toHaveTextContent('200');
       expect(container).toHaveTextContent('instructor_1');
@@ -167,17 +173,20 @@ describe('CoursesDetailPage', () => {
 
   test('Should render the class name filter input', () => {
     const { getByTestId } = renderComponent();
+
     expect(getByTestId('class_name')).toBeInTheDocument();
   });
 
   test('Should render the start date and end date filter inputs', () => {
     const { getByTestId } = renderComponent();
+
     expect(getByTestId('start_date')).toBeInTheDocument();
     expect(getByTestId('end_date')).toBeInTheDocument();
   });
 
   test('Apply and Reset buttons should be disabled when no filter has changed', () => {
     const { getByText } = renderComponent();
+
     expect(getByText('Apply')).toBeDisabled();
     expect(getByText('Reset')).toBeDisabled();
   });
@@ -189,14 +198,16 @@ describe('CoursesDetailPage', () => {
       target: { value: 'Demo Class' },
     });
 
-    expect(getByText('Apply')).not.toBeDisabled();
-    expect(getByText('Reset')).not.toBeDisabled();
+    expect(getByText('Apply')).toBeEnabled();
+    expect(getByText('Reset')).toBeEnabled();
   });
 
   test('Apply and Reset buttons should remain disabled when class name has less than 2 chars and dates are default', () => {
     const { getByTestId, getByText } = renderComponent();
 
-    fireEvent.change(getByTestId('class_name'), { target: { value: 'D' } });
+    fireEvent.change(getByTestId('class_name'), {
+      target: { value: 'D' },
+    });
 
     expect(getByText('Apply')).toBeDisabled();
     expect(getByText('Reset')).toBeDisabled();
@@ -205,19 +216,23 @@ describe('CoursesDetailPage', () => {
   test('Apply and Reset buttons should be enabled when start_date changes from default', () => {
     const { getByTestId, getByText } = renderComponent();
 
-    fireEvent.change(getByTestId('start_date'), { target: { value: '2023-06-01' } });
+    fireEvent.change(getByTestId('start_date'), {
+      target: { value: '2023-06-01' },
+    });
 
-    expect(getByText('Apply')).not.toBeDisabled();
-    expect(getByText('Reset')).not.toBeDisabled();
+    expect(getByText('Apply')).toBeEnabled();
+    expect(getByText('Reset')).toBeEnabled();
   });
 
   test('Apply and Reset buttons should be enabled when end_date changes from default', () => {
     const { getByTestId, getByText } = renderComponent();
 
-    fireEvent.change(getByTestId('end_date'), { target: { value: '2025-03-15' } });
+    fireEvent.change(getByTestId('end_date'), {
+      target: { value: '2025-03-15' },
+    });
 
-    expect(getByText('Apply')).not.toBeDisabled();
-    expect(getByText('Reset')).not.toBeDisabled();
+    expect(getByText('Apply')).toBeEnabled();
+    expect(getByText('Reset')).toBeEnabled();
   });
 
   test('Should dispatch fetchClassesData with class_name filter on Apply', async () => {
@@ -233,7 +248,7 @@ describe('CoursesDetailPage', () => {
       expect(fetchClassesData).toHaveBeenCalledWith(
         1,
         1,
-        'course-v1:XXX+YYY+2023',
+        courseId,
         expect.objectContaining({ class_name: 'Demo Class' }),
       );
     });
@@ -242,21 +257,27 @@ describe('CoursesDetailPage', () => {
   test('Should clear all filters and refetch', async () => {
     const { getByTestId, getByText } = renderComponent();
 
-    fireEvent.change(getByTestId('class_name'), { target: { value: 'Demo Class' } });
-    fireEvent.change(getByTestId('start_date'), { target: { value: '2023-06-01' } });
-    fireEvent.change(getByTestId('end_date'), { target: { value: '2023-12-31' } });
+    fireEvent.change(getByTestId('class_name'), {
+      target: { value: 'Demo Class' },
+    });
+    fireEvent.change(getByTestId('start_date'), {
+      target: { value: '2023-06-01' },
+    });
+    fireEvent.change(getByTestId('end_date'), {
+      target: { value: '2023-12-31' },
+    });
+
     fireEvent.click(getByText('Reset'));
 
     await waitFor(() => {
       expect(getByTestId('class_name')).toHaveValue('');
       expect(getByTestId('start_date')).toHaveValue('');
       expect(getByTestId('end_date')).toHaveValue('');
-
       expect(fetchClassesData).toHaveBeenLastCalledWith(
         1,
         1,
-        'course-v1:XXX+YYY+2023',
-        expect.objectContaining({}),
+        courseId,
+        {},
       );
     });
   });
@@ -264,15 +285,31 @@ describe('CoursesDetailPage', () => {
   test('Should disable Apply and Reset buttons after Reset', async () => {
     const { getByTestId, getByText } = renderComponent();
 
-    fireEvent.change(getByTestId('class_name'), {
+    const classNameInput = getByTestId('class_name');
+    const applyButton = getByText('Apply');
+    const resetButton = getByText('Reset');
+
+    fireEvent.change(classNameInput, {
       target: { value: 'Demo Class' },
     });
 
-    fireEvent.click(getByText('Reset'));
+    expect(classNameInput).toHaveValue('Demo Class');
+    expect(applyButton).toBeEnabled();
+    expect(resetButton).toBeEnabled();
+
+    fireEvent.click(resetButton);
 
     await waitFor(() => {
-      expect(getByText('Apply')).toBeDisabled();
-      expect(getByText('Reset')).toBeDisabled();
+      expect(classNameInput).toHaveValue('');
+      expect(applyButton).toBeDisabled();
+      expect(resetButton).toBeDisabled();
     });
+
+    expect(fetchClassesData).toHaveBeenLastCalledWith(
+      1,
+      1,
+      courseId,
+      {},
+    );
   });
 });


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3557

## Description

This PR updates the Class Overview analytics UI to display the new Pass/Fail Rate widget returned by Course Operations.

The existing class analytics API, Redux thunk, and state management are reused. The frontend now supports an optional widget subtitle so the Pass/Fail Rate card can display both the percentage and its supporting learner counts.

Example:

```
Pass/Fail Rate
88%
7 passed, 1 failed
```

<img width="3546" height="1078" alt="image" src="https://github.com/user-attachments/assets/0826c294-b2bc-4d29-ba9b-16fd9675a688" />

## Changes made

- [x] Updated ClassAnalyticsWidgets to pass the optional backend subtitle field to MetricCard.
- [x] Updated MetricCard to render an optional subtitle.
- [x] Added subtitle styling consistent with the Class Overview design.
- [x] Preserved the existing rendering behavior for Class Average Score.
- [x] Preserved support for multiple widgets returned by the existing endpoint.
- [x] Improved value handling so numeric zero values render correctly.
- [x] Added unit tests.

## API response consumed

The frontend expects the existing endpoint to return a widget array:

```
{
  "class_id": "ccx-v1:VUE+AZ900+2026+ccx@103",
  "widgets": [
    {
      "key": "class_average_score",
      "title": "Class Average Score",
      "value": 0.9,
      "formatted_value": "90.0%",
      "trend": null,
      "formatted_trend": null
    },
    {
      "key": "pass_fail_rate",
      "title": "Pass/Fail Rate",
      "value": 0.875,
      "formatted_value": "88%",
      "subtitle": "7 passed, 1 failed",
      "trend": null,
      "formatted_trend": null
    }
  ]
}

```
## How to test
- Enable the class analytics widgets feature flag.
- Open a Class Details page for a class with grade data.
- Confirm that the Class overview section displays:
    - Class Average Score;
    - Pass/Fail Rate;
    - passed and failed learner counts.
- Confirm that the cards render correctly on desktop and mobile layouts.
- Confirm that a widget without a subtitle still renders correctly.
- Run the related frontend tests.

```
npm test -- \
  src/features/Common/MetricCard/__test__/index.test.jsx \
  src/features/Classes/ClassAnalyticsWidgets/__test__/index.test.jsx
```

## Reviewers

- [x] @daviidco