### PR TITLE
PADV-3552: Refresh ClassPage on voucher assignment and revocation

### DIFF
--- a/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/columns.test.jsx
@@ -2,6 +2,7 @@ import { Route } from 'react-router-dom';
 import { fireEvent } from '@testing-library/react';
 
 import { renderWithProviders } from 'test-utils';
+import VoucherOptions from 'features/Main/VoucherOptions';
 import { getColumns } from '../columns';
 
 jest.mock('@edx/frontend-platform', () => ({
@@ -11,7 +12,13 @@ jest.mock('@edx/frontend-platform', () => ({
   })),
 }));
 
+jest.mock('features/Main/VoucherOptions', () => jest.fn(() => null));
+
 describe('getColumns', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const mockStore = {
     main: {
       selectedInstitution: { id: 1 },
@@ -277,7 +284,11 @@ describe('getColumns', () => {
   });
 
   test('renders Voucher option only when displayVoucherOptions = true', () => {
-    const columns = getColumns({ displayVoucherOptions: true });
+    const onVoucherActionSuccess = jest.fn();
+    const columns = getColumns({
+      displayVoucherOptions: true,
+      onVoucherActionSuccess,
+    });
 
     const ActionColumn = () => columns[9].Cell({
       row: {
@@ -303,7 +314,17 @@ describe('getColumns', () => {
 
     fireEvent.click(component.getByTestId('droprown-action'));
 
-    expect(component.getByText('Assign a voucher')).toBeInTheDocument();
+    expect(VoucherOptions).toHaveBeenCalled();
+
+    const voucherOptionsProps = VoucherOptions.mock.calls[VoucherOptions.mock.calls.length - 1][0];
+
+    expect(voucherOptionsProps).toEqual(expect.objectContaining({
+      courseId: 'course-v1:demo+demo1+2020',
+      learnerEmail: 'testuser@example.com',
+      showAssign: true,
+      showRevoke: undefined,
+      onVoucherActionSuccess,
+    }));
   });
 
   test('does NOT render Voucher option when displayVoucherOptions = false', () => {
@@ -329,7 +350,7 @@ describe('getColumns', () => {
 
     fireEvent.click(component.getByTestId('droprown-action'));
 
-    expect(component.queryByText('Assign a voucher')).not.toBeInTheDocument();
+    expect(VoucherOptions).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/Classes/Class/ClassPage/columns.jsx
+++ b/src/features/Classes/Class/ClassPage/columns.jsx
@@ -18,7 +18,11 @@ import VoucherOptions from 'features/Main/VoucherOptions';
 
 import { VOUCHER_BADGE_VARIANTS } from 'features/constants';
 
-const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false } = {}) => ([
+const getColumns = ({
+  displayVoucherOptions = false,
+  enableVoucherColumn = false,
+  onVoucherActionSuccess = () => {},
+} = {}) => ([
   {
     Header: 'No',
     accessor: 'index',
@@ -212,6 +216,7 @@ const getColumns = ({ displayVoucherOptions = false, enableVoucherColumn = false
                 learnerEmail={learnerEmail}
                 showAssign={voucherInfo?.showAssign}
                 showRevoke={voucherInfo?.showRevoke}
+                onVoucherActionSuccess={onVoucherActionSuccess}
               />
             )}
             {

--- a/src/features/Classes/Class/ClassPage/index.jsx
+++ b/src/features/Classes/Class/ClassPage/index.jsx
@@ -3,11 +3,13 @@ import React, {
   useEffect,
   useRef,
   useMemo,
+  useCallback,
 } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { Container, Pagination } from '@openedx/paragon';
 import { useDispatch, useSelector } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform';
+import { logError } from '@edx/frontend-platform/logging';
 
 import Table from 'features/Main/Table';
 import InstructorCard from 'features/Classes/InstructorCard';
@@ -66,6 +68,7 @@ const ClassPage = () => {
   const {
     data: studentsData = {},
     isFetching: isLoadingStudents,
+    refetch: refetchStudents,
   } = useGetStudentsByClassQuery(
     {
       institutionId: institution.id,
@@ -188,9 +191,30 @@ const ClassPage = () => {
     });
   };
 
+  const refreshStudentsList = useCallback(async () => {
+    try {
+      const studentsRefreshResult = await refetchStudents();
+
+      if (studentsRefreshResult?.error) {
+        logError(studentsRefreshResult.error);
+        return;
+      }
+
+      if (institution.id && displayVoucherOptions) {
+        await dispatch(fetchStudentsVouchers(displayVoucherOptions));
+      }
+    } catch (error) {
+      logError(error);
+    }
+  }, [refetchStudents, institution.id, displayVoucherOptions, dispatch]);
+
   const COLUMNS = useMemo(() => (
-    getColumns({ displayVoucherOptions, enableVoucherColumn })
-  ), [displayVoucherOptions, enableVoucherColumn]);
+    getColumns({
+      displayVoucherOptions,
+      enableVoucherColumn,
+      onVoucherActionSuccess: refreshStudentsList,
+    })
+  ), [displayVoucherOptions, enableVoucherColumn, refreshStudentsList]);
 
   useEffect(() => {
     const initialTitle = document.title;

--- a/src/features/Main/VoucherOptions/__test__/index.test.jsx
+++ b/src/features/Main/VoucherOptions/__test__/index.test.jsx
@@ -91,8 +91,14 @@ describe('VoucherOptions', () => {
   test('should show success message when voucher is assigned successfully', async () => {
     getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
     assignVoucher.mockResolvedValueOnce({ status: HTTP_STATUS.CREATED });
+    const onVoucherActionSuccess = jest.fn();
 
-    renderWithProviders(<VoucherOptions {...baseProps} />);
+    renderWithProviders(
+      <VoucherOptions
+        {...baseProps}
+        onVoucherActionSuccess={onVoucherActionSuccess}
+      />,
+    );
 
     fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.ASSIGN));
 
@@ -108,6 +114,29 @@ describe('VoucherOptions', () => {
     await waitFor(() => {
       expect(screen.getByText(VOUCHER_SUCCESS_MESSAGES.ASSIGN)).toBeInTheDocument();
     });
+
+    expect(onVoucherActionSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not call onVoucherActionSuccess when assignment fails', async () => {
+    getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
+    assignVoucher.mockRejectedValueOnce({});
+    const onVoucherActionSuccess = jest.fn();
+
+    renderWithProviders(
+      <VoucherOptions
+        {...baseProps}
+        onVoucherActionSuccess={onVoucherActionSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.ASSIGN));
+
+    await waitFor(() => {
+      expect(screen.getByText(VOUCHER_ERROR_MESSAGES.ASSIGN)).toBeInTheDocument();
+    });
+
+    expect(onVoucherActionSuccess).not.toHaveBeenCalled();
   });
 
   test('should show custom error message from error.response.data.detail when assignment fails', async () => {
@@ -165,8 +194,14 @@ describe('VoucherOptions', () => {
   test('should show success message when voucher is revoked successfully', async () => {
     getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
     revokeVoucher.mockResolvedValueOnce({ status: HTTP_STATUS.SUCCESS });
+    const onVoucherActionSuccess = jest.fn();
 
-    renderWithProviders(<VoucherOptions {...baseProps} />);
+    renderWithProviders(
+      <VoucherOptions
+        {...baseProps}
+        onVoucherActionSuccess={onVoucherActionSuccess}
+      />,
+    );
 
     fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.REVOKE));
 
@@ -182,6 +217,29 @@ describe('VoucherOptions', () => {
     await waitFor(() => {
       expect(screen.getByText(VOUCHER_SUCCESS_MESSAGES.REVOKE)).toBeInTheDocument();
     });
+
+    expect(onVoucherActionSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not call onVoucherActionSuccess when revoke fails', async () => {
+    getConfig.mockReturnValue({ PSS_ENABLE_ASSIGN_VOUCHER: true });
+    revokeVoucher.mockRejectedValueOnce({});
+    const onVoucherActionSuccess = jest.fn();
+
+    renderWithProviders(
+      <VoucherOptions
+        {...baseProps}
+        onVoucherActionSuccess={onVoucherActionSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(VOUCHER_UI_LABELS.REVOKE));
+
+    await waitFor(() => {
+      expect(screen.getByText(VOUCHER_ERROR_MESSAGES.REVOKE)).toBeInTheDocument();
+    });
+
+    expect(onVoucherActionSuccess).not.toHaveBeenCalled();
   });
 
   test('should show not found message on 404 revoke error', async () => {

--- a/src/features/Main/VoucherOptions/index.jsx
+++ b/src/features/Main/VoucherOptions/index.jsx
@@ -37,7 +37,11 @@ function reducer(state, action) {
 }
 
 const VoucherOptions = ({
-  courseId, learnerEmail, showAssign, showRevoke,
+  courseId,
+  learnerEmail,
+  showAssign,
+  showRevoke,
+  onVoucherActionSuccess,
 }) => {
   const enableOption = getConfig().PSS_ENABLE_ASSIGN_VOUCHER || false;
   const institution = useSelector((state) => state.main.selectedInstitution);
@@ -77,6 +81,7 @@ const VoucherOptions = ({
 
       if (response?.status === HTTP_STATUS.CREATED) {
         showMessage(VOUCHER_SUCCESS_MESSAGES.ASSIGN);
+        onVoucherActionSuccess();
       }
     } catch (error) {
       const errorMessage = error?.response?.data?.detail || VOUCHER_ERROR_MESSAGES.ASSIGN;
@@ -84,7 +89,7 @@ const VoucherOptions = ({
     } finally {
       dispatch({ type: VOUCHER_ACTIONS.ASSIGN_END });
     }
-  }, [assignLoading, invalidInputs, makePayload, showMessage]);
+  }, [assignLoading, invalidInputs, makePayload, showMessage, onVoucherActionSuccess]);
 
   const handleRevokeVoucher = useCallback(async () => {
     if (revokeLoading || invalidInputs) { return; }
@@ -96,6 +101,7 @@ const VoucherOptions = ({
 
       if (response?.status === HTTP_STATUS.SUCCESS) {
         showMessage(VOUCHER_SUCCESS_MESSAGES.REVOKE);
+        onVoucherActionSuccess();
       }
     } catch (error) {
       const status = error?.customAttributes?.httpErrorStatus;
@@ -117,7 +123,7 @@ const VoucherOptions = ({
     } finally {
       dispatch({ type: VOUCHER_ACTIONS.REVOKE_END });
     }
-  }, [revokeLoading, invalidInputs, makePayload, showMessage]);
+  }, [revokeLoading, invalidInputs, makePayload, showMessage, onVoucherActionSuccess]);
 
   if (!enableOption) { return null; }
 
@@ -162,6 +168,11 @@ VoucherOptions.propTypes = {
   learnerEmail: PropTypes.string.isRequired,
   showAssign: PropTypes.bool.isRequired,
   showRevoke: PropTypes.bool.isRequired,
+  onVoucherActionSuccess: PropTypes.func,
+};
+
+VoucherOptions.defaultProps = {
+  onVoucherActionSuccess: () => {},
 };
 
 export default VoucherOptions;

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -187,7 +187,7 @@ export const HTTP_STATUS = {
  * @enum {string}
  */
 export const VOUCHER_SUCCESS_MESSAGES = {
-  ASSIGN: 'The action was completed. Please Refresh your screen.',
+  ASSIGN: 'Voucher assigned successfully.',
   REVOKE: 'Voucher revoked successfully.',
 };
 


### PR DESCRIPTION
## Ticket 

- https://pearson.atlassian.net/browse/PADV-3552

## Description

This PR improves the voucher assign/revoke implementation on the class roster page, more specifically it enables the page to automatically refresh the student data after the assign or revoke action is successful, if this mechanism fails the page is reloaded instead.