### PR TITLE
PADV-3531 - Make gradebook download available from action menu of a class

### DIFF
--- a/src/features/Classes/Class/ClassPage/Actions.jsx
+++ b/src/features/Classes/Class/ClassPage/Actions.jsx
@@ -24,7 +24,7 @@ import EnrollStudent from 'features/Classes/EnrollStudent';
 
 import { resetClassState } from 'features/Courses/data/slice';
 import { deleteClass } from 'features/Courses/data/thunks';
-import { fetchLabSummaryLink } from 'features/Classes/data/thunks';
+import { fetchLabSummaryLink, downloadGradebookCsv } from 'features/Classes/data/thunks';
 import { classesApi, useGetClassesByCourseQuery } from 'features/Classes/data/classesApi';
 
 const initialDeletionClassState = {
@@ -49,6 +49,7 @@ const Actions = ({ previousPage }) => {
   } = useToast();
 
   const [deletionClassState, setDeletionState] = useState(initialDeletionClassState);
+  const [isDownloadingGradebook, setIsDownloadingGradebook] = useState(false);
 
   const classLink = `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classIdDecoded}/home`;
 
@@ -82,6 +83,20 @@ const Actions = ({ previousPage }) => {
 
   const handleGradebookButton = () => {
     window.open(`${gradebookUrl}/gradebook/${classIdDecoded}`, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleDownloadGradebook = async () => {
+    if (isDownloadingGradebook) {
+      return;
+    }
+
+    setIsDownloadingGradebook(true);
+
+    try {
+      await dispatch(downloadGradebookCsv(classIdDecoded, showToast));
+    } finally {
+      setIsDownloadingGradebook(false);
+    }
   };
 
   const handleResetDeletion = () => {
@@ -166,6 +181,14 @@ const Actions = ({ previousPage }) => {
           <Dropdown.Item onClick={handleGradebookButton}>
             <i className="fa-regular fa-book mr-2 mb-1" />
             Gradebook
+          </Dropdown.Item>
+          <Dropdown.Item
+            onClick={handleDownloadGradebook}
+            disabled={isDownloadingGradebook}
+            data-testid="download-gradebook-action"
+          >
+            <i className="fa-regular fa-download mr-2 mb-1" />
+            {isDownloadingGradebook ? 'Downloading gradebook…' : 'Download gradebook'}
           </Dropdown.Item>
           {classInfo?.labSummaryTag && (
             <Dropdown.Item onClick={handleLabSummary}>

--- a/src/features/Classes/Class/ClassPage/__test__/index.test.jsx
+++ b/src/features/Classes/Class/ClassPage/__test__/index.test.jsx
@@ -88,6 +88,7 @@ describe('ClassesPage', () => {
       expect(getByText('Edit Class')).toBeInTheDocument();
       expect(getByText('Delete Class')).toBeInTheDocument();
       expect(getByText('Gradebook')).toBeInTheDocument();
+      expect(getByText('Download gradebook')).toBeInTheDocument();
       expect(getByText('Lab summary')).toBeInTheDocument();
     });
   });

--- a/src/features/Classes/ClassesTable/_test_/columns.test.jsx
+++ b/src/features/Classes/ClassesTable/_test_/columns.test.jsx
@@ -9,6 +9,7 @@ import * as classesThunks from 'features/Classes/data/thunks';
 jest.mock('features/Classes/data/thunks', () => ({
   ...jest.requireActual('features/Classes/data/thunks'),
   supersetUrlClassesDashboard: jest.fn(),
+  downloadGradebookCsv: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-platform', () => ({
@@ -84,6 +85,7 @@ describe('columns', () => {
 
   beforeEach(() => {
     classesThunks.supersetUrlClassesDashboard.mockResolvedValue(null);
+    classesThunks.downloadGradebookCsv.mockReturnValue(() => Promise.resolve());
   });
 
   afterEach(() => {
@@ -172,8 +174,53 @@ describe('columns', () => {
     expect(getByText('Manage Instructors')).toBeInTheDocument();
     expect(getByText('Edit Class')).toBeInTheDocument();
     expect(getByText('Gradebook')).toBeInTheDocument();
+    expect(getByText('Download gradebook')).toBeInTheDocument();
     expect(getByText('Enroll student')).toBeInTheDocument();
     expect(getByText('Delete Class')).toBeInTheDocument();
+  });
+
+  test('Downloads the gradebook when the action is clicked', async () => {
+    const ActionColumn = () => columns[8].Cell({
+      row: {
+        values: {
+          masterCourseName: 'course example',
+        },
+        original: { ...classDataMock },
+      },
+    });
+
+    const mockStore = {
+      classes: {
+        table: {
+          data: [
+            { ...classDataMock },
+          ],
+          count: 2,
+          num_pages: 1,
+          current_page: 1,
+        },
+        allClasses: {
+          data: [
+            { ...classDataMock },
+          ],
+        },
+      },
+    };
+
+    const { getByTestId } = renderWithProviders(<ActionColumn />, {
+      preloadedState: mockStore,
+      initialEntries: ['/classes/'],
+    });
+
+    fireEvent.click(getByTestId('droprown-action'));
+    fireEvent.click(getByTestId('download-gradebook-action'));
+
+    await waitFor(() => {
+      expect(classesThunks.downloadGradebookCsv).toHaveBeenCalledWith(
+        classDataMock.classId,
+        expect.any(Function),
+      );
+    });
   });
 
   test('Show Lab Dashboard option when link is sent', async () => {

--- a/src/features/Classes/ClassesTable/columns.jsx
+++ b/src/features/Classes/ClassesTable/columns.jsx
@@ -22,7 +22,7 @@ import EnrollStudent from 'features/Classes/EnrollStudent';
 import { RequestStatus, modalDeleteText } from 'features/constants';
 
 import { deleteClass } from 'features/Courses/data/thunks';
-import { fetchLabSummaryLink, supersetUrlClassesDashboard } from 'features/Classes/data/thunks';
+import { fetchLabSummaryLink, supersetUrlClassesDashboard, downloadGradebookCsv } from 'features/Classes/data/thunks';
 import { classesApi } from 'features/Classes/data/classesApi';
 
 import { formatUTCDate, setAssignStaffRole } from 'helpers';
@@ -132,6 +132,7 @@ const columns = [
       const [isOpenModal, openModal, closeModal] = useToggle(false);
       const [isOpenEnrollModal, openEnrollModal, closeEnrollModal] = useToggle(false);
       const [deletionClassState, setDeletionState] = useState(initialDeletionClassState);
+      const [isDownloadingGradebook, setIsDownloadingGradebook] = useState(false);
       const gradebookUrl = getConfig().GRADEBOOK_MICROFRONTEND_URL || getConfig().LMS_BASE_URL;
       const {
         isVisible,
@@ -151,6 +152,20 @@ const columns = [
 
       const handleGradebookButton = () => {
         window.open(`${gradebookUrl}/gradebook/${classId}`, '_blank', 'noopener,noreferrer');
+      };
+
+      const handleDownloadGradebook = async () => {
+        if (isDownloadingGradebook) {
+          return;
+        }
+
+        setIsDownloadingGradebook(true);
+
+        try {
+          await dispatch(downloadGradebookCsv(classId, showToast));
+        } finally {
+          setIsDownloadingGradebook(false);
+        }
       };
 
       const handleDeleteClass = async (rowClassId) => {
@@ -254,6 +269,14 @@ const columns = [
             <Dropdown.Item onClick={handleGradebookButton}>
               <i className="fa-regular fa-book mr-2 mb-1" />
               Gradebook
+            </Dropdown.Item>
+            <Dropdown.Item
+              onClick={handleDownloadGradebook}
+              disabled={isDownloadingGradebook}
+              data-testid="download-gradebook-action"
+            >
+              <i className="fa-regular fa-download mr-2 mb-1" />
+              {isDownloadingGradebook ? 'Downloading gradebook…' : 'Download gradebook'}
             </Dropdown.Item>
             {classesDashboardUrl && (
               <Dropdown.Item

--- a/src/features/Classes/data/_test_/api.test.js
+++ b/src/features/Classes/data/_test_/api.test.js
@@ -1,6 +1,6 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
-import { handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
+import { getGradebookCsv, handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedHttpClient: jest.fn(),
@@ -12,14 +12,27 @@ jest.mock('@edx/frontend-platform', () => ({
 
 describe('API functions', () => {
   const mockPost = jest.fn();
+  const mockGet = jest.fn();
   const mockConfig = {
     LMS_BASE_URL: 'https://example.com',
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    getAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
+    getAuthenticatedHttpClient.mockReturnValue({ post: mockPost, get: mockGet });
     getConfig.mockReturnValue(mockConfig);
+  });
+
+  describe('getGradebookCsv', () => {
+    it('should request the gradebook CSV as a blob for the given class', async () => {
+      const classId = 'ccx-v1:PX+CS00002+2023+ccx@39';
+      const expectedUrl = `${mockConfig.LMS_BASE_URL}/courses/${classId}/ccx_grades.csv`;
+
+      await getGradebookCsv(classId);
+
+      expect(getAuthenticatedHttpClient).toHaveBeenCalled();
+      expect(mockGet).toHaveBeenCalledWith(expectedUrl, { responseType: 'blob' });
+    });
   });
 
   describe('handleSkillableDashboard', () => {

--- a/src/features/Classes/data/_test_/thunks.gradebook.test.js
+++ b/src/features/Classes/data/_test_/thunks.gradebook.test.js
@@ -1,0 +1,74 @@
+import { logError } from '@edx/frontend-platform/logging';
+
+import { getGradebookCsv } from 'features/Classes/data/api';
+import { downloadGradebookCsv } from 'features/Classes/data/thunks';
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({})),
+  camelCaseObject: jest.fn((value) => value),
+}));
+
+jest.mock('features/Classes/data/api', () => ({
+  getClassAnalyticsWidgets: jest.fn(),
+  getGradebookCsv: jest.fn(),
+  handleSkillableDashboard: jest.fn(),
+  handleXtremeLabsDashboard: jest.fn(),
+}));
+
+describe('downloadGradebookCsv thunk', () => {
+  const dispatch = jest.fn();
+  const classId = 'ccx-v1:PX+CS00002+2023+ccx@39';
+  let showToast;
+  let clickMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    showToast = jest.fn();
+    clickMock = jest.fn();
+
+    window.URL.createObjectURL = jest.fn(() => 'blob:url');
+    window.URL.revokeObjectURL = jest.fn();
+
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      setAttribute: jest.fn(),
+      click: clickMock,
+      remove: jest.fn(),
+      href: '',
+    });
+    jest.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('Shows an in-progress toast and triggers the browser download', async () => {
+    getGradebookCsv.mockResolvedValue({ data: 'name,grade\n' });
+
+    await downloadGradebookCsv(classId, showToast)(dispatch);
+
+    expect(showToast).toHaveBeenCalledWith(
+      'Your gradebook download is in progress. This may take a moment.',
+    );
+    expect(getGradebookCsv).toHaveBeenCalledWith(classId);
+    expect(clickMock).toHaveBeenCalledTimes(1);
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:url');
+  });
+
+  test('Shows an error toast and logs the error when the request fails', async () => {
+    const error = new Error('Request failed');
+    getGradebookCsv.mockRejectedValue(error);
+
+    await downloadGradebookCsv(classId, showToast)(dispatch);
+
+    expect(showToast).toHaveBeenLastCalledWith(
+      'An error occurred while downloading the gradebook. Please try again.',
+    );
+    expect(clickMock).not.toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/features/Classes/data/api.js
+++ b/src/features/Classes/data/api.js
@@ -52,8 +52,22 @@ function getClassAnalyticsWidgets({ institutionId, classId }) {
   );
 }
 
+/**
+ * Download the Gradebook of a class as a CSV file.
+ *
+ * @param {string} classId - CCX course id of the class.
+ * @returns {Promise} Authenticated HTTP response with the CSV file as a blob.
+ */
+function getGradebookCsv(classId) {
+  return getAuthenticatedHttpClient().get(
+    `${getConfig().LMS_BASE_URL}/courses/${classId}/ccx_grades.csv`,
+    { responseType: 'blob' },
+  );
+}
+
 export {
   getClassAnalyticsWidgets,
+  getGradebookCsv,
   handleSkillableDashboard,
   handleXtremeLabsDashboard,
 };

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -17,6 +17,7 @@ import {
 
 import {
   getClassAnalyticsWidgets,
+  getGradebookCsv,
   handleSkillableDashboard,
   handleXtremeLabsDashboard,
 } from 'features/Classes/data/api';
@@ -140,6 +141,42 @@ function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
 }
 
 /**
+ * Download the Gradebook of a class as a CSV file.
+ *
+ * Shows an in-progress toast, requests the CSV from the LMS and lets the
+ * browser download the resulting file. The returned promise resolves once the
+ * request completes (or rejects on error) so callers can block the trigger and
+ * avoid duplicated requests while the operation is in progress.
+ *
+ * @param {string} classId - CCX course id of the class.
+ * @param {Function} showToast - Callback used to display notifications.
+ * @returns {Function} Redux thunk returning a promise.
+ */
+function downloadGradebookCsv(classId, showToast) {
+  return async () => {
+    try {
+      showToast('Your gradebook download is in progress. This may take a moment.');
+
+      const response = await getGradebookCsv(classId);
+
+      const blob = new Blob([response.data], { type: 'text/csv' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+
+      link.href = url;
+      link.setAttribute('download', `ccx_grades_${classId}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      showToast('An error occurred while downloading the gradebook. Please try again.');
+      logError(error);
+    }
+  };
+}
+
+/**
  * Builds the Superset “Classes” dashboard URL if the feature is enabled.
  *
  * @param {string} classId
@@ -186,5 +223,6 @@ export {
   fetchAllClassesData,
   fetchClassAnalyticsWidgets,
   fetchLabSummaryLink,
+  downloadGradebookCsv,
   supersetUrlClassesDashboard,
 };


### PR DESCRIPTION
# Description
Adds a new "Download gradebook" action to the class action menu, allowing administrators to download a class Gradebook as a CSV file. The action is available in every location where the existing "Gradebook" action appears, across both PSS and IP.

When triggered, it requests `{LMS_BASE_URL}/courses/{ccx_course_id}/ccx_grades.csv` and lets the browser download the resulting file.

## Ticket
https://pearson.atlassian.net/browse/PADV-3531

### Changes
- **api.js**: New `getGradebookCsv(classId)` that fetches the CSV as a blob via the authenticated HTTP client.
- **thunks.js**: New `downloadGradebookCsv(classId, showToast)` thunk that shows an in-progress notification, retrieves the CSV, triggers the browser download, and surfaces an error notification on failure.
- **Actions.jsx** (Class detail page) and **columns.jsx** (Classes table): New "Download gradebook" menu item placed alongside the existing "Gradebook" option, reusing the same `classId` (CCX course key) and display conditions.

### Manual test plan
1. Open a page containing the class action menu.
2. Confirm "Download gradebook" is displayed together with "Gradebook".
3. Click "Download gradebook" and verify a request is made to `{LMS_BASE_URL}/courses/{ccx_course_id}/ccx_grades.csv`.
4. Verify the browser downloads the CSV file.
5. Verify the action is disabled and labeled "Downloading gradebook…" while in progress, and that repeated clicks do not trigger multiple requests.
6. Confirm the existing "Gradebook" navigation still works without regressions.
